### PR TITLE
fix: missing return result from date picker

### DIFF
--- a/lib/src/widgets/adaptive_date_picker.dart
+++ b/lib/src/widgets/adaptive_date_picker.dart
@@ -150,7 +150,7 @@ class _CupertinoDatePickerContentState
                 ),
                 CupertinoButton(
                   padding: EdgeInsets.zero,
-                  onPressed: () => Navigator.of(context).pop(true),
+                  onPressed: () => Navigator.of(context).pop(selectedDate),
                   child: Text(
                     MaterialLocalizations.of(context).okButtonLabel,
                     style: const TextStyle(fontWeight: FontWeight.w600),


### PR DESCRIPTION
## Description
Date picker returns bool result instead of the expected `DateTime?`.

## Type of Change
<!-- Please check the relevant option(s) -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
