### PR TITLE
fix: AdaptiveSwitch, ios26 flutter size

### DIFF
--- a/lib/src/widgets/ios26/ios26_switch.dart
+++ b/lib/src/widgets/ios26/ios26_switch.dart
@@ -138,8 +138,8 @@ class _IOS26SwitchState extends State<IOS26Switch> {
       );
 
       return SizedBox(
-        width: 51, // Standard iOS switch width
-        height: 31, // Standard iOS switch height
+        width: 63, // Standard iOS switch width
+        height: 29, // Standard iOS switch height
         child: platformView,
       );
     }


### PR DESCRIPTION
## Description
Fixes size of the Flutter container for iOS 26 switch

I think they changed the size between sometimes before 26.0.1 but I don't have all the emulators installed. Optionally, there could be an if-statement checking for the version.

## Type of Change
<!-- Please check the relevant option(s) -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
<!-- Link any related issues here -->
Closes #44

## Changes Made
<!-- List the specific changes made in this PR -->
- Changed size

## Testing

### Automated Tests ⚠️ **REQUIRED**
<!-- All PRs that add or modify functionality MUST include tests -->
- [ ] I have added unit/widget tests for my changes
- [ ] All new and existing tests pass locally (`flutter test`)
- [ ] Code analysis passes with no errors (`flutter analyze`)
- [ ] Code formatting is correct (`dart format`)
- [ ] Test coverage is adequate (>80% for new code)

### Manual Testing

Tested on both ios 26.0.1 and ios 26.1. 

- [x] iOS 26+ tested
- [ ] iOS <26 tested
- [ ] Android tested
- [ ] Web tested (if applicable)
- [ ] Tested in both light and dark mode
- [ ] Tested with different screen sizes
- [ ] Tested with accessibility features (large fonts, screen readers, etc.)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos demonstrating the changes -->

### Before
<img width="119" height="90" alt="Screenshot 2025-11-14 at 14 27 29" src="https://github.com/user-attachments/assets/0b2254f6-34d3-41c6-8a71-c56a95782643" />

### After
<img width="603" height="1311" alt="Screenshot 2025-11-14 at 15 03 00" src="https://github.com/user-attachments/assets/9fe79dbe-eade-42f9-8b72-15a590629024" />
