### PR TITLE
fix(ios): remove white overlay on iOS 26 native switch

### DIFF
--- a/ios/Classes/iOS26SwitchView.swift
+++ b/ios/Classes/iOS26SwitchView.swift
@@ -46,6 +46,7 @@ class iOS26SwitchView: NSObject, FlutterPlatformView {
         binaryMessenger messenger: FlutterBinaryMessenger
     ) {
         _view = UIView(frame: frame)
+        _view.backgroundColor = .clear
 
         // Extract configuration from arguments
         if let config = args as? [String: Any] {


### PR DESCRIPTION
## Summary
- The `UIView` container in `IOS26SwitchView` defaults to an opaque white background
- This causes a visible white rectangle behind the native `UISwitch` when rendered inside sheets or on non-white/transparent surfaces
- Fixed by setting `_view.backgroundColor = .clear`

## Change
One line in `ios/Classes/iOS26SwitchView.swift`:
```swift
_view.backgroundColor = .clear
```

## Test plan
- [ ] Use `AdaptiveSwitch` inside a sheet with a non-white background on iOS 26+
- [ ] Verify no white overlay appears behind the switch
- [ ] Verify switch still functions correctly (toggle, haptic feedback, color)

🤖 Generated with [Claude Code](https://claude.com/claude-code)