### PR TITLE
feat: Add tintColor and prominent button support for iOS 26+ toolbar

### DIFF
--- a/example/lib/pages/demos/toolbar_tint_demo_page.dart
+++ b/example/lib/pages/demos/toolbar_tint_demo_page.dart
@@ -1,0 +1,518 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+
+class ToolbarTintDemoPage extends StatefulWidget {
+  const ToolbarTintDemoPage({super.key});
+
+  @override
+  State<ToolbarTintDemoPage> createState() => _ToolbarTintDemoPageState();
+}
+
+class _ToolbarTintDemoPageState extends State<ToolbarTintDemoPage> {
+  int _selectedColorIndex = 0;
+  int _checkmarkTintIndex = 2; // Green by default
+  int _heartTintIndex = 1; // Red by default
+
+  static const _tintOptions = <_TintOption>[
+    _TintOption(name: 'Blue', color: Colors.blue),
+    _TintOption(name: 'Red', color: Colors.red),
+    _TintOption(name: 'Green', color: Colors.green),
+    _TintOption(name: 'Orange', color: Colors.orange),
+    _TintOption(name: 'Purple', color: Colors.purple),
+    _TintOption(name: 'System Default', color: null),
+  ];
+
+  Color? get _currentTint => _tintOptions[_selectedColorIndex].color;
+  Color? get _checkmarkTint => _tintOptions[_checkmarkTintIndex].color;
+  Color? get _heartTint => _tintOptions[_heartTintIndex].color;
+
+  @override
+  Widget build(BuildContext context) {
+    return AdaptiveScaffold(
+      appBar: AdaptiveAppBar(
+        title: '',
+        useNativeToolbar: true,
+        tintColor: _currentTint,
+        actions: [
+          // Standard action — inherits global tint
+          AdaptiveAppBarAction(
+            iosSymbol: 'star',
+            icon: Icons.star_outline,
+            onPressed: () {},
+          ),
+          // Prominent action — glass bubble style
+          AdaptiveAppBarAction(
+            iosSymbol: 'plus',
+            icon: Icons.add,
+            prominent: true,
+            onPressed: () {},
+          ),
+          // Per-action tint override
+          AdaptiveAppBarAction(
+            iosSymbol: 'checkmark.circle',
+            icon: Icons.check_circle_outline,
+            tintColor: _checkmarkTint,
+            onPressed: () {},
+          ),
+          // Prominent + per-action tint
+          AdaptiveAppBarAction(
+            iosSymbol: 'heart.fill',
+            icon: Icons.favorite,
+            prominent: true,
+            tintColor: _heartTint,
+            onPressed: () {},
+          ),
+        ],
+      ),
+      body: _buildBody(context),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    final isDark = PlatformInfo.isIOS
+        ? MediaQuery.platformBrightnessOf(context) == Brightness.dark
+        : Theme.of(context).brightness == Brightness.dark;
+
+    return SafeArea(
+      top: false,
+      bottom: false,
+      child: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 120, 16, 32),
+        children: [
+          _buildSectionHeader(context, 'Global Tint Color', isDark),
+          const SizedBox(height: 8),
+          _buildDescription(
+            context,
+            'Tap a color to change the toolbar\'s global tintColor. '
+            'All actions without a per-action tint will update.',
+            isDark,
+          ),
+          const SizedBox(height: 12),
+          _buildColorPicker(context, isDark),
+          const SizedBox(height: 24),
+          _buildSectionHeader(context, 'Toolbar Actions', isDark),
+          const SizedBox(height: 8),
+          _buildActionInfo(
+            context,
+            icon: Icons.star_outline,
+            title: 'Star — Standard',
+            description: 'Inherits the global tint color.',
+            isDark: isDark,
+          ),
+          _buildActionInfo(
+            context,
+            icon: Icons.add,
+            title: 'Plus — Prominent',
+            description:
+                'Uses prominent: true for a glass bubble style (iOS 26+).',
+            isDark: isDark,
+          ),
+          _buildActionInfoWithPicker(
+            context,
+            icon: Icons.check_circle_outline,
+            title: 'Checkmark — Per-action tint',
+            description: 'Per-action tintColor override, ignoring global tint.',
+            isDark: isDark,
+            selectedIndex: _checkmarkTintIndex,
+            onChanged: (i) => setState(() => _checkmarkTintIndex = i),
+          ),
+          _buildActionInfoWithPicker(
+            context,
+            icon: Icons.favorite,
+            title: 'Heart — Prominent + per-action tint',
+            description:
+                'Combines prominent: true with per-action tintColor.',
+            isDark: isDark,
+            selectedIndex: _heartTintIndex,
+            onChanged: (i) => setState(() => _heartTintIndex = i),
+          ),
+          const SizedBox(height: 24),
+          _buildSectionHeader(context, 'Platform Behavior', isDark),
+          const SizedBox(height: 8),
+          _buildPlatformInfo(context, isDark),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSectionHeader(
+    BuildContext context,
+    String title,
+    bool isDark,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 4),
+      child: Text(
+        title,
+        style: TextStyle(
+          fontSize: 20,
+          fontWeight: FontWeight.bold,
+          color: PlatformInfo.isIOS
+              ? (isDark ? CupertinoColors.white : CupertinoColors.black)
+              : Theme.of(context).colorScheme.onSurface,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDescription(
+    BuildContext context,
+    String text,
+    bool isDark,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 4),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 14,
+          color: PlatformInfo.isIOS
+              ? (isDark
+                    ? CupertinoColors.systemGrey
+                    : CupertinoColors.systemGrey2)
+              : Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildColorPicker(BuildContext context, bool isDark) {
+    return Wrap(
+      spacing: 10,
+      runSpacing: 10,
+      children: List.generate(_tintOptions.length, (index) {
+        final option = _tintOptions[index];
+        final isSelected = _selectedColorIndex == index;
+        final displayColor = option.color ??
+            (PlatformInfo.isIOS
+                ? CupertinoColors.systemBlue
+                : Theme.of(context).colorScheme.primary);
+
+        return GestureDetector(
+          onTap: () => setState(() => _selectedColorIndex = index),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            decoration: BoxDecoration(
+              color: isSelected
+                  ? displayColor.withValues(alpha: 0.2)
+                  : (isDark
+                        ? Colors.white.withValues(alpha: 0.05)
+                        : Colors.black.withValues(alpha: 0.04)),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: isSelected
+                    ? displayColor
+                    : (isDark
+                          ? Colors.white.withValues(alpha: 0.1)
+                          : Colors.black.withValues(alpha: 0.1)),
+                width: isSelected ? 2 : 1,
+              ),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (option.color != null)
+                  Container(
+                    width: 16,
+                    height: 16,
+                    decoration: BoxDecoration(
+                      color: option.color,
+                      shape: BoxShape.circle,
+                    ),
+                  )
+                else
+                  Icon(
+                    PlatformInfo.isIOS
+                        ? CupertinoIcons.circle
+                        : Icons.circle_outlined,
+                    size: 16,
+                    color: isDark ? Colors.white54 : Colors.black45,
+                  ),
+                const SizedBox(width: 8),
+                Text(
+                  option.name,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                    color: isSelected
+                        ? displayColor
+                        : (isDark ? Colors.white : Colors.black87),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      }),
+    );
+  }
+
+  Widget _buildActionInfo(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required String description,
+    required bool isDark,
+  }) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 10),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: isDark
+            ? (PlatformInfo.isIOS
+                  ? CupertinoColors.darkBackgroundGray
+                  : Theme.of(context).colorScheme.surfaceContainerHighest)
+            : (PlatformInfo.isIOS
+                  ? CupertinoColors.white
+                  : Theme.of(context).colorScheme.surfaceContainerHighest),
+        borderRadius: BorderRadius.circular(12),
+        border: PlatformInfo.isIOS
+            ? Border.all(
+                color: isDark
+                    ? CupertinoColors.systemGrey4
+                    : CupertinoColors.separator,
+                width: 0.5,
+              )
+            : null,
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 24, color: _currentTint ?? Colors.blue),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                    color: isDark ? Colors.white : Colors.black87,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  description,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: isDark ? Colors.white54 : Colors.black54,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActionInfoWithPicker(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required String description,
+    required bool isDark,
+    required int selectedIndex,
+    required ValueChanged<int> onChanged,
+  }) {
+    final actionColor = _tintOptions[selectedIndex].color ?? Colors.blue;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 10),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: isDark
+            ? (PlatformInfo.isIOS
+                  ? CupertinoColors.darkBackgroundGray
+                  : Theme.of(context).colorScheme.surfaceContainerHighest)
+            : (PlatformInfo.isIOS
+                  ? CupertinoColors.white
+                  : Theme.of(context).colorScheme.surfaceContainerHighest),
+        borderRadius: BorderRadius.circular(12),
+        border: PlatformInfo.isIOS
+            ? Border.all(
+                color: isDark
+                    ? CupertinoColors.systemGrey4
+                    : CupertinoColors.separator,
+                width: 0.5,
+              )
+            : null,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, size: 24, color: actionColor),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.w600,
+                        color: isDark ? Colors.white : Colors.black87,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      description,
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: isDark ? Colors.white54 : Colors.black54,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          _buildMiniColorPicker(
+            context,
+            isDark: isDark,
+            selectedIndex: selectedIndex,
+            onChanged: onChanged,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMiniColorPicker(
+    BuildContext context, {
+    required bool isDark,
+    required int selectedIndex,
+    required ValueChanged<int> onChanged,
+  }) {
+    return Row(
+      children: List.generate(_tintOptions.length, (index) {
+        final option = _tintOptions[index];
+        final isSelected = selectedIndex == index;
+        final color = option.color;
+
+        return Padding(
+          padding: const EdgeInsets.only(right: 8),
+          child: GestureDetector(
+            onTap: () => onChanged(index),
+            child: Container(
+              width: 28,
+              height: 28,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: color ?? (isDark ? Colors.grey.shade700 : Colors.grey.shade300),
+                border: Border.all(
+                  color: isSelected
+                      ? (isDark ? Colors.white : Colors.black87)
+                      : Colors.transparent,
+                  width: 2.5,
+                ),
+              ),
+              child: color == null
+                  ? Icon(
+                      Icons.block,
+                      size: 14,
+                      color: isDark ? Colors.white54 : Colors.black45,
+                    )
+                  : null,
+            ),
+          ),
+        );
+      }),
+    );
+  }
+
+  Widget _buildPlatformInfo(BuildContext context, bool isDark) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: PlatformInfo.isIOS
+            ? (isDark
+                  ? CupertinoColors.darkBackgroundGray
+                  : CupertinoColors.white)
+            : Theme.of(context).colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+        border: PlatformInfo.isIOS
+            ? Border.all(
+                color: isDark
+                    ? CupertinoColors.systemGrey4
+                    : CupertinoColors.separator,
+                width: 0.5,
+              )
+            : null,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildPlatformRow(
+            'iOS 26+',
+            'Native UINavigationBar tintColor + prominent style',
+            isDark,
+          ),
+          const SizedBox(height: 8),
+          _buildPlatformRow(
+            'iOS <26',
+            'Cupertino app bar (tint/prominent ignored)',
+            isDark,
+          ),
+          const SizedBox(height: 8),
+          _buildPlatformRow(
+            'Android',
+            'Material app bar (tint/prominent ignored)',
+            isDark,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildPlatformRow(String platform, String info, bool isDark) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 6,
+          height: 6,
+          margin: const EdgeInsets.only(top: 6),
+          decoration: BoxDecoration(
+            color: isDark ? Colors.white54 : Colors.black45,
+            shape: BoxShape.circle,
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: RichText(
+            text: TextSpan(
+              style: TextStyle(
+                fontSize: 14,
+                color: isDark ? Colors.white70 : Colors.black54,
+              ),
+              children: [
+                TextSpan(
+                  text: '$platform: ',
+                  style: TextStyle(
+                    fontWeight: FontWeight.w600,
+                    color: isDark ? Colors.white : Colors.black87,
+                  ),
+                ),
+                TextSpan(text: info),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _TintOption {
+  final String name;
+  final Color? color;
+  const _TintOption({required this.name, required this.color});
+}

--- a/example/lib/pages/home/home_page.dart
+++ b/example/lib/pages/home/home_page.dart
@@ -343,6 +343,16 @@ class _HomePageState extends State<HomePage> {
               ),
               _DemoItem(
                 icon: PlatformInfo.isIOS
+                    ? CupertinoIcons.paintbrush
+                    : Icons.color_lens,
+                title: 'Toolbar Tint',
+                description:
+                    'Tint color and prominent buttons for native toolbar',
+                routeName: RouterService.routes.toolbarTint,
+                isNew: true,
+              ),
+              _DemoItem(
+                icon: PlatformInfo.isIOS
                     ? CupertinoIcons.search_circle_fill
                     : Icons.search,
                 title: 'Native Search Tab',

--- a/example/lib/service/router/router_service.dart
+++ b/example/lib/service/router/router_service.dart
@@ -28,6 +28,7 @@ import 'package:adaptive_platform_ui_example/pages/demos/form_section_demo_page.
 import 'package:adaptive_platform_ui_example/pages/demos/expansion_tile_demo_page.dart';
 import 'package:adaptive_platform_ui_example/pages/demos/blur_view_demo_page.dart';
 import 'package:adaptive_platform_ui_example/pages/demos/drawer_demo_page.dart';
+import 'package:adaptive_platform_ui_example/pages/demos/toolbar_tint_demo_page.dart';
 import 'package:adaptive_platform_ui_example/pages/demos/navigation_page1.dart';
 import 'package:adaptive_platform_ui_example/pages/demos/navigation_page2.dart';
 import 'package:adaptive_platform_ui_example/pages/demos/navigation_page3.dart';
@@ -249,6 +250,12 @@ class RouterService {
                     name: routes.drawer,
                     path: routes.drawer,
                     builder: (context, state) => const DrawerDemoPage(),
+                  ),
+                  GoRoute(
+                    name: routes.toolbarTint,
+                    path: routes.toolbarTint,
+                    builder: (context, state) =>
+                        const ToolbarTintDemoPage(),
                   ),
                   GoRoute(
                     name: routes.navigationPage1,

--- a/example/lib/utils/constants/route_constants.dart
+++ b/example/lib/utils/constants/route_constants.dart
@@ -33,6 +33,7 @@ class RouteConstants {
   String expansionTile = 'expansion-tile';
   String blurView = 'blur-view';
   String drawer = 'drawer';
+  String toolbarTint = 'toolbar-tint';
   String navigationPage1 = 'navigation-page1';
   String navigationPage2 = 'navigation-page2';
   String navigationPage3 = 'navigation-page3';

--- a/ios/Classes/iOS26ToolbarPlatformView.swift
+++ b/ios/Classes/iOS26ToolbarPlatformView.swift
@@ -85,6 +85,10 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
         setupNavigationBar()
 
         if let params = args as? [String: Any] {
+            // Apply tint color before configuring items so buttons inherit it
+            if let n = params["tint"] as? NSNumber {
+                navigationBar.tintColor = Self.colorFromARGB(n.intValue)
+            }
             configureItems(params)
         }
 
@@ -281,8 +285,25 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
                 }
             }
             result(nil)
+        case "setStyle":
+            if let args = call.arguments as? [String: Any] {
+                if let n = args["tint"] as? NSNumber {
+                    navigationBar.tintColor = Self.colorFromARGB(n.intValue)
+                }
+            }
+            result(nil)
         default:
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    // MARK: - Color Helpers
+
+    private static func colorFromARGB(_ argb: Int) -> UIColor {
+        let a = CGFloat((argb >> 24) & 0xFF) / 255.0
+        let r = CGFloat((argb >> 16) & 0xFF) / 255.0
+        let g = CGFloat((argb >> 8) & 0xFF) / 255.0
+        let b = CGFloat(argb & 0xFF) / 255.0
+        return UIColor(red: r, green: g, blue: b, alpha: a)
     }
 }

--- a/ios/Classes/iOS26ToolbarPlatformView.swift
+++ b/ios/Classes/iOS26ToolbarPlatformView.swift
@@ -55,6 +55,7 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
     private var channel: FlutterMethodChannel
 
     private var isDark: Bool = false
+    private var perActionTintTags: Set<Int> = []
 
     init(
         frame: CGRect,
@@ -86,14 +87,16 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
 
         if let params = args as? [String: Any] {
             configureItems(params)
-            // Apply tint color after configuring items
+            // Apply global tint color after configuring items
             if let n = params["tint"] as? NSNumber {
                 let color = Self.colorFromARGB(n.intValue)
                 containerView.tintColor = color
                 navigationBar.tintColor = color
-                // Also tint individual items directly
+                // Apply to items that don't have their own per-action tint
                 for item in (navigationItem.leftBarButtonItems ?? []) + (navigationItem.rightBarButtonItems ?? []) {
-                    item.tintColor = color
+                    if !perActionTintTags.contains(item.tag) {
+                        item.tintColor = color
+                    }
                 }
             }
         }
@@ -238,6 +241,7 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
                     // Apply per-action tint color
                     if let n = action["tint"] as? NSNumber {
                         btn.tintColor = Self.colorFromARGB(n.intValue)
+                        perActionTintTags.insert(index)
                     }
 
                     // If no flexible spacer exists, all go to right
@@ -303,6 +307,20 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
                 }
             }
             result(nil)
+        case "updateActions":
+            if let args = call.arguments as? [String: Any] {
+                perActionTintTags.removeAll()
+                configureItems(args)
+                // Re-apply global tint to items without per-action tint
+                if let globalTint = navigationBar.tintColor {
+                    for item in (navigationItem.leftBarButtonItems ?? []) + (navigationItem.rightBarButtonItems ?? []) {
+                        if !perActionTintTags.contains(item.tag) {
+                            item.tintColor = globalTint
+                        }
+                    }
+                }
+            }
+            result(nil)
         case "setStyle":
             if let args = call.arguments as? [String: Any] {
                 if let tintValue = args["tint"] {
@@ -311,13 +329,17 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
                         containerView.tintColor = color
                         navigationBar.tintColor = color
                         for item in (navigationItem.leftBarButtonItems ?? []) + (navigationItem.rightBarButtonItems ?? []) {
-                            item.tintColor = color
+                            if !perActionTintTags.contains(item.tag) {
+                                item.tintColor = color
+                            }
                         }
                     } else if tintValue is NSNull {
                         containerView.tintColor = nil
                         navigationBar.tintColor = nil
                         for item in (navigationItem.leftBarButtonItems ?? []) + (navigationItem.rightBarButtonItems ?? []) {
-                            item.tintColor = nil
+                            if !perActionTintTags.contains(item.tag) {
+                                item.tintColor = nil
+                            }
                         }
                     }
                 }

--- a/ios/Classes/iOS26ToolbarPlatformView.swift
+++ b/ios/Classes/iOS26ToolbarPlatformView.swift
@@ -328,8 +328,6 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
         }
     }
 
-    // MARK: - Color Helpers
-
     private static func colorFromARGB(_ argb: Int) -> UIColor {
         let a = CGFloat((argb >> 24) & 0xFF) / 255.0
         let r = CGFloat((argb >> 16) & 0xFF) / 255.0

--- a/ios/Classes/iOS26ToolbarPlatformView.swift
+++ b/ios/Classes/iOS26ToolbarPlatformView.swift
@@ -85,11 +85,17 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
         setupNavigationBar()
 
         if let params = args as? [String: Any] {
-            // Apply tint color before configuring items so buttons inherit it
-            if let n = params["tint"] as? NSNumber {
-                navigationBar.tintColor = Self.colorFromARGB(n.intValue)
-            }
             configureItems(params)
+            // Apply tint color after configuring items
+            if let n = params["tint"] as? NSNumber {
+                let color = Self.colorFromARGB(n.intValue)
+                containerView.tintColor = color
+                navigationBar.tintColor = color
+                // Also tint individual items directly
+                for item in (navigationItem.leftBarButtonItems ?? []) + (navigationItem.rightBarButtonItems ?? []) {
+                    item.tintColor = color
+                }
+            }
         }
 
         channel.setMethodCallHandler { [weak self] call, result in
@@ -222,6 +228,18 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
                 if let btn = button {
                     btn.tag = index
 
+                    // Apply prominent style (iOS 26+)
+                    if action["prominent"] as? Bool == true {
+                        if #available(iOS 26.0, *) {
+                            btn.style = .prominent
+                        }
+                    }
+
+                    // Apply per-action tint color
+                    if let n = action["tint"] as? NSNumber {
+                        btn.tintColor = Self.colorFromARGB(n.intValue)
+                    }
+
                     // If no flexible spacer exists, all go to right
                     // If flexible exists, split by it
                     if !hasFlexible {
@@ -287,8 +305,21 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
             result(nil)
         case "setStyle":
             if let args = call.arguments as? [String: Any] {
-                if let n = args["tint"] as? NSNumber {
-                    navigationBar.tintColor = Self.colorFromARGB(n.intValue)
+                if let tintValue = args["tint"] {
+                    if let n = tintValue as? NSNumber {
+                        let color = Self.colorFromARGB(n.intValue)
+                        containerView.tintColor = color
+                        navigationBar.tintColor = color
+                        for item in (navigationItem.leftBarButtonItems ?? []) + (navigationItem.rightBarButtonItems ?? []) {
+                            item.tintColor = color
+                        }
+                    } else if tintValue is NSNull {
+                        containerView.tintColor = nil
+                        navigationBar.tintColor = nil
+                        for item in (navigationItem.leftBarButtonItems ?? []) + (navigationItem.rightBarButtonItems ?? []) {
+                            item.tintColor = nil
+                        }
+                    }
                 }
             }
             result(nil)

--- a/lib/src/widgets/adaptive_app_bar.dart
+++ b/lib/src/widgets/adaptive_app_bar.dart
@@ -21,6 +21,7 @@ class AdaptiveAppBar {
     this.actions,
     this.leading,
     this.useNativeToolbar = true,
+    this.tintColor,
     this.cupertinoNavigationBar,
     this.appBar,
   });
@@ -48,6 +49,13 @@ class AdaptiveAppBar {
   /// If true, [cupertinoNavigationBar] will be ignored and native toolbar will be shown.
   final bool useNativeToolbar;
 
+  /// Tint color for toolbar action buttons (iOS 26+ native toolbar only)
+  ///
+  /// When set, this color is applied to the navigation bar's tintColor,
+  /// which colors all bar button items (action buttons and back button).
+  /// If null, the system default tint color is used.
+  final Color? tintColor;
+
   /// Custom CupertinoNavigationBar for iOS
   ///
   /// When provided and [useNativeToolbar] is false, this custom navigation bar will be used
@@ -70,6 +78,7 @@ class AdaptiveAppBar {
     List<AdaptiveAppBarAction>? actions,
     Widget? leading,
     bool? useNativeToolbar,
+    Color? tintColor,
     PreferredSizeWidget? cupertinoNavigationBar,
     PreferredSizeWidget? appBar,
   }) {
@@ -78,6 +87,7 @@ class AdaptiveAppBar {
       actions: actions ?? this.actions,
       leading: leading ?? this.leading,
       useNativeToolbar: useNativeToolbar ?? this.useNativeToolbar,
+      tintColor: tintColor ?? this.tintColor,
       cupertinoNavigationBar:
           cupertinoNavigationBar ?? this.cupertinoNavigationBar,
       appBar: appBar ?? this.appBar,

--- a/lib/src/widgets/adaptive_app_bar_action.dart
+++ b/lib/src/widgets/adaptive_app_bar_action.dart
@@ -25,6 +25,8 @@ class AdaptiveAppBarAction {
     this.title,
     required this.onPressed,
     this.spacerAfter = ToolbarSpacerType.none,
+    this.prominent = false,
+    this.tintColor,
   }) : assert(
          iosSymbol != null || icon != null || title != null,
          'At least one of iosSymbol, icon, or title must be provided',
@@ -65,17 +67,30 @@ class AdaptiveAppBarAction {
   /// ```
   final ToolbarSpacerType spacerAfter;
 
+  /// Display this action with a prominent glass background (iOS 26+ only)
+  /// - iOS 26+: Uses UIBarButtonItem.Style.prominent for a tinted glass bubble
+  /// - iOS <26 / Android: Ignored
+  final bool prominent;
+
+  /// Per-action tint color (iOS 26+ only)
+  /// Overrides the global AdaptiveAppBar.tintColor for this specific action.
+  /// Useful for highlighting individual buttons (e.g., green call button).
+  /// - iOS <26 / Android: Ignored
+  final Color? tintColor;
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     return other is AdaptiveAppBarAction &&
         other.iosSymbol == iosSymbol &&
         other.icon == icon &&
-        other.title == title;
+        other.title == title &&
+        other.prominent == prominent &&
+        other.tintColor == tintColor;
   }
 
   @override
-  int get hashCode => Object.hash(iosSymbol, icon, title);
+  int get hashCode => Object.hash(iosSymbol, icon, title, prominent, tintColor);
 
   /// Convert action to map for native platform channel (iOS 26+ only)
   Map<String, dynamic> toNativeMap() {
@@ -83,6 +98,8 @@ class AdaptiveAppBarAction {
       if (iosSymbol != null) 'icon': iosSymbol!,
       if (title != null) 'title': title!,
       'spacerAfter': spacerAfter.index, // 0=none, 1=fixed, 2=flexible
+      if (prominent) 'prominent': true,
+      if (tintColor != null) 'tint': tintColor!.toARGB32(),
     };
   }
 }

--- a/lib/src/widgets/adaptive_card.dart
+++ b/lib/src/widgets/adaptive_card.dart
@@ -170,9 +170,7 @@ class _IOSCard extends StatelessWidget {
         color: backgroundColor,
         borderRadius: radius,
         border: Border.all(
-          color: isDark
-              ? CupertinoColors.systemGrey6
-              : CupertinoColors.separator,
+          color: CupertinoColors.separator.resolveFrom(context),
           width: 0.5,
         ),
         boxShadow: isDark

--- a/lib/src/widgets/adaptive_card.dart
+++ b/lib/src/widgets/adaptive_card.dart
@@ -170,7 +170,9 @@ class _IOSCard extends StatelessWidget {
         color: backgroundColor,
         borderRadius: radius,
         border: Border.all(
-          color: CupertinoColors.separator.resolveFrom(context),
+          color: isDark
+              ? CupertinoColors.systemGrey6
+              : CupertinoColors.separator,
           width: 0.5,
         ),
         boxShadow: isDark

--- a/lib/src/widgets/adaptive_scaffold.dart
+++ b/lib/src/widgets/adaptive_scaffold.dart
@@ -235,6 +235,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
           title: widget.appBar?.title,
           actions: widget.appBar?.actions,
           leading: widget.appBar?.leading,
+          tintColor: widget.appBar?.tintColor,
           minimizeBehavior: widget.minimizeBehavior,
           enableBlur: widget.enableBlur,
           useHeroBackButton: widget.useHeroBackButton,

--- a/lib/src/widgets/ios26/ios26_native_toolbar.dart
+++ b/lib/src/widgets/ios26/ios26_native_toolbar.dart
@@ -75,6 +75,13 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
   void didUpdateWidget(IOS26NativeToolbar oldWidget) {
     super.didUpdateWidget(oldWidget);
     _syncPropsToNativeIfNeeded();
+
+    if (widget.title != oldWidget.title) {
+      final ch = _channel;
+      if (ch != null && widget.title != null) {
+        ch.invokeMethod('updateTitle', {'title': widget.title!});
+      }
+    }
   }
 
   Future<void> _syncPropsToNativeIfNeeded() async {

--- a/lib/src/widgets/ios26/ios26_native_toolbar.dart
+++ b/lib/src/widgets/ios26/ios26_native_toolbar.dart
@@ -45,6 +45,7 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
   MethodChannel? _channel;
   bool? _lastIsDark;
   int? _lastTint;
+  List<AdaptiveAppBarAction>? _lastActions;
 
   bool get _isDark =>
       MediaQuery.platformBrightnessOf(context) == Brightness.dark;
@@ -91,6 +92,21 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
       }
     }
 
+    // Sync actions (per-action tint, prominent, etc.)
+    final actions = widget.actions;
+    if (_lastActions != null && !_actionsEqual(_lastActions!, actions)) {
+      try {
+        final params = <String, dynamic>{
+          if (actions != null && actions.isNotEmpty)
+            'actions': actions.map((a) => a.toNativeMap()).toList(),
+        };
+        await ch.invokeMethod('updateActions', params);
+        _lastActions = actions != null ? List.of(actions) : null;
+      } catch (e) {
+        // Ignore errors if platform view is not yet ready
+      }
+    }
+
     // Sync tint color
     final tint =
         widget.tintColor != null ? _colorToARGB(widget.tintColor!) : null;
@@ -102,6 +118,17 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
         // Ignore errors if platform view is not yet ready
       }
     }
+  }
+
+  bool _actionsEqual(
+      List<AdaptiveAppBarAction>? a, List<AdaptiveAppBarAction>? b) {
+    if (identical(a, b)) return true;
+    if (a == null || b == null) return false;
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
   }
 
   @override
@@ -155,6 +182,8 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
     _lastIsDark = _isDark;
     _lastTint =
         widget.tintColor != null ? _colorToARGB(widget.tintColor!) : null;
+    _lastActions =
+        widget.actions != null ? List.of(widget.actions!) : null;
   }
 
   Future<dynamic> _handleMethodCall(MethodCall call) async {

--- a/lib/src/widgets/ios26/ios26_native_toolbar.dart
+++ b/lib/src/widgets/ios26/ios26_native_toolbar.dart
@@ -94,7 +94,7 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
     // Sync tint color
     final tint =
         widget.tintColor != null ? _colorToARGB(widget.tintColor!) : null;
-    if (tint != null && _lastTint != tint) {
+    if (_lastTint != tint) {
       try {
         await ch.invokeMethod('setStyle', {'tint': tint});
         _lastTint = tint;

--- a/lib/src/widgets/ios26/ios26_scaffold.dart
+++ b/lib/src/widgets/ios26/ios26_scaffold.dart
@@ -15,6 +15,7 @@ class IOS26Scaffold extends StatefulWidget {
     this.title,
     this.actions,
     this.leading,
+    this.tintColor,
     this.minimizeBehavior = TabBarMinimizeBehavior.automatic,
     this.enableBlur = true,
     this.useHeroBackButton = true,
@@ -25,6 +26,7 @@ class IOS26Scaffold extends StatefulWidget {
   final String? title;
   final List<AdaptiveAppBarAction>? actions;
   final Widget? leading;
+  final Color? tintColor;
   final TabBarMinimizeBehavior minimizeBehavior;
   final bool enableBlur;
   final bool useHeroBackButton;
@@ -193,6 +195,7 @@ class _IOS26ScaffoldState extends State<IOS26Scaffold>
               leading: widget.leading ?? heroLeading,
               showNativeView: showNativeView,
               actions: widget.actions,
+              tintColor: widget.tintColor,
               onActionTap: (index) {
                 // Call the appropriate action callback
                 if (widget.actions != null &&


### PR DESCRIPTION
## Summary

- **Global tint color**: New `AdaptiveAppBar.tintColor` property to color all toolbar bar button items (back button + actions) on iOS 26+ native toolbar
- **Per-action tint color**: New `AdaptiveAppBarAction.tintColor` to override the global tint on individual buttons (e.g. a green call button)
- **Prominent button style**: New `AdaptiveAppBarAction.prominent` flag for iOS 26+ `UIBarButtonItem.Style.prominent` (tinted glass bubble)
- **Dynamic tint sync**: Tint color updates at runtime via method channel, including clearing back to system default

## Test plan

- [X] `flutter analyze --fatal-infos` passes
- [X] All 206 tests pass

![example](https://github.com/user-attachments/assets/24dc2592-4049-48ce-987c-cac621875b25)