### PR TITLE
fix: support dynamic title updates in iOS 26 native toolbar

### DIFF
--- a/lib/src/widgets/ios26/ios26_native_toolbar.dart
+++ b/lib/src/widgets/ios26/ios26_native_toolbar.dart
@@ -42,6 +42,17 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
     _syncBrightnessIfNeeded();
   }
 
+  @override
+  void didUpdateWidget(IOS26NativeToolbar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.title != oldWidget.title) {
+      final ch = _channel;
+      if (ch != null && widget.title != null) {
+        ch.invokeMethod('updateTitle', {'title': widget.title!});
+      }
+    }
+  }
+
   Future<void> _syncBrightnessIfNeeded() async {
     final ch = _channel;
     if (ch == null) return;


### PR DESCRIPTION
## Description

When using `AdaptiveAppBar` with a dynamically changing `title` (e.g., showing "Typing..." indicator in a chat app), the iOS 26 native toolbar does not reflect the updated title after the initial render.

### Root Cause

In `ios26_native_toolbar.dart`, the `didUpdateWidget` method was missing, so changes to the `title` property were never forwarded to the native iOS view via `methodChannel.invokeMethod('updateTitle', ...)`.

### Changes

- Added `didUpdateWidget` override in `_IOS26NativeToolbarState` to detect title changes and invoke the native `updateTitle` method
- Added corresponding `updateTitle` handler in `iOS26ToolbarView.swift` to update the native `UINavigationItem.title`

### Testing

- Verified in a chat app: toolbar title dynamically switches between contact name and "Typing..." indicator
- No regressions observed in static title usage

## Related Issues

This is a new feature/fix not covered by existing issues.