### PR TITLE
fix: resolve Auto Layout constraint conflict between SizedBox(38) and UIButton(36)

### DIFF
--- a/lib/src/widgets/adaptive_scaffold.dart
+++ b/lib/src/widgets/adaptive_scaffold.dart
@@ -938,8 +938,8 @@ class _AnimatedBackButtonState extends State<_AnimatedBackButton>
         );
       },
       child: SizedBox(
-        height: 38,
-        width: 38,
+        height: 36,
+        width: 36,
         child: AdaptiveButton.sfSymbol(
           onPressed: _handlePressed,
           sfSymbol: SFSymbol("chevron.left", size: 20),

--- a/lib/src/widgets/ios26/ios26_scaffold.dart
+++ b/lib/src/widgets/ios26/ios26_scaffold.dart
@@ -118,8 +118,8 @@ class _IOS26ScaffoldState extends State<IOS26Scaffold>
       final isCurrent = ModalRoute.of(context)?.isCurrent ?? true;
       if (isCurrent) {
         final backButton = SizedBox(
-          height: 38,
-          width: 38,
+          height: 36,
+          width: 36,
           child: AdaptiveButton.sfSymbol(
             onPressed: () => Navigator.of(context).pop(),
             sfSymbol: SFSymbol("chevron.left", size: 20),
@@ -134,7 +134,7 @@ class _IOS26ScaffoldState extends State<IOS26Scaffold>
               )
             : backButton;
       } else {
-        const placeholder = SizedBox(height: 38, width: 38);
+        const placeholder = SizedBox(height: 36, width: 36);
         heroLeading = widget.useHeroBackButton
             ? const Hero(tag: 'adaptive_back_button', child: placeholder)
             : placeholder;


### PR DESCRIPTION
## Description

Fixes the Auto Layout constraint conflict reported in #88.

On iOS 26, the console is flooded with constraint conflict warnings:

```
Will attempt to recover by breaking constraint
<NSLayoutConstraint UIButton.height == 36 (active)>
```

### Root Cause

In `ios26_scaffold.dart`, the `SizedBox` wrapping toolbar action buttons uses `height: 38, width: 38`, but the native `iOS26ButtonView.swift` returns `36pt` for medium-sized buttons via `getHeightForSize()`. The 2pt mismatch causes Auto Layout to break the button height constraint.

### Changes

- Changed `SizedBox` dimensions from `38x38` to `36x36` in:
  - `ios26_scaffold.dart` (lines 121-122, 137)
  - `adaptive_scaffold.dart` (lines 941-942)
- This aligns the Flutter container with the iOS standard medium button height (36pt)

### Testing

- Auto Layout constraint warnings completely eliminated
- Button tap targets remain functional
- No visual regression observed

## Related Issues

Closes #88