### PR TITLE
refactor: enable support for custom asset-based icons and RTL layout …

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,14 +42,16 @@ class _AdaptivePlatformUIDemoState extends State<AdaptivePlatformUIDemo> {
         brightness: Brightness.dark,
       ),
       localizationsDelegates: [
+        // Important!
         GlobalMaterialLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate, // Important!
-        DefaultWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
       ],
       locale: const Locale('en'),
       supportedLocales: [
         const Locale('en'), // English
         const Locale('tr'), // Turkish
+        const Locale('ar'), // Arabic
         // ... other locales the app supports
       ],
       routerConfig: routerService.router,

--- a/ios/Classes/iOS26TabBarPlatformView.swift
+++ b/ios/Classes/iOS26TabBarPlatformView.swift
@@ -29,6 +29,7 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
         var spacerFlags: [Bool] = []
         var selectedIndex: Int = 0
         var isDark: Bool = false
+        var isRtl: Bool = false
         var tint: UIColor? = nil
         var bg: UIColor? = nil
         var minimize: Int = 3 // automatic
@@ -48,6 +49,7 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
             }
             if let v = dict["selectedIndex"] as? NSNumber { selectedIndex = v.intValue }
             if let v = dict["isDark"] as? NSNumber { isDark = v.boolValue }
+            if let v = dict["isRtl"] as? NSNumber { isRtl = v.boolValue }
             if let n = dict["tint"] as? NSNumber { tint = Self.colorFromARGB(n.intValue) }
             if let n = dict["unselectedItemTint"] as? NSNumber {
                 unselectedTint = Self.colorFromARGB(n.intValue)
@@ -70,6 +72,8 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
         tabBar = bar
         bar.delegate = self
         bar.translatesAutoresizingMaskIntoConstraints = false
+        bar.semanticContentAttribute = isRtl ? .forceRightToLeft : .forceLeftToRight
+        container.semanticContentAttribute = isRtl ? .forceRightToLeft : .forceLeftToRight
 
         // iOS 26+ special handling - Skip appearance, use direct properties only
         if #available(iOS 26.0, *) {
@@ -477,6 +481,18 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
             if #available(iOS 13.0, *) {
                 self.container.overrideUserInterfaceStyle = isDark ? .dark : .light
             }
+            result(nil)
+
+        case "setDirectionality":
+            guard let args = call.arguments as? [String: Any],
+                  let isRtl = (args["isRtl"] as? NSNumber)?.boolValue else {
+                result(FlutterError(code: "bad_args", message: "Missing isRtl", details: nil))
+                return
+            }
+
+            let attribute: UISemanticContentAttribute = isRtl ? .forceRightToLeft : .forceLeftToRight
+            self.tabBar?.semanticContentAttribute = attribute
+            self.container.semanticContentAttribute = attribute
             result(nil)
 
         case "setMinimizeBehavior":

--- a/lib/src/widgets/ios26/ios26_native_tab_bar.dart
+++ b/lib/src/widgets/ios26/ios26_native_tab_bar.dart
@@ -50,6 +50,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
   int? _lastUnselectedTint;
   int? _lastBg;
   bool? _lastIsDark;
+  bool? _lastIsRtl;
   double? _intrinsicHeight;
   List<String>? _lastLabels;
   List<String>? _lastSymbols;
@@ -61,6 +62,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
 
   bool get _isDark =>
       MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+  bool get _isRtl => Directionality.of(context) == TextDirection.rtl;
   Color? get _effectiveTint =>
       widget.tint ?? CupertinoTheme.of(context).primaryColor;
 
@@ -74,6 +76,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     _syncBrightnessIfNeeded();
+    _syncDirectionalityIfNeeded();
     _syncPropsToNativeIfNeeded();
   }
 
@@ -153,6 +156,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
         'spacerFlags': spacerFlags,
         'selectedIndex': widget.selectedIndex,
         'isDark': _isDark,
+        'isRtl': _isRtl,
         'minimizeBehavior': widget.minimizeBehavior.index,
         if (_effectiveTint != null) 'tint': _colorToARGB(_effectiveTint!),
         if (widget.unselectedItemTint != null)
@@ -231,6 +235,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
         ? _colorToARGB(widget.backgroundColor!)
         : null;
     _lastIsDark = _isDark;
+    _lastIsRtl = _isRtl;
     _lastMinimizeBehavior = widget.minimizeBehavior;
     _requestIntrinsicSize();
     _cacheItems();
@@ -341,6 +346,16 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
     if (_lastIsDark != isDark) {
       await ch.invokeMethod('setBrightness', {'isDark': isDark});
       _lastIsDark = isDark;
+    }
+  }
+
+  Future<void> _syncDirectionalityIfNeeded() async {
+    final ch = _channel;
+    if (ch == null) return;
+    final isRtl = _isRtl;
+    if (_lastIsRtl != isRtl) {
+      await ch.invokeMethod('setDirectionality', {'isRtl': isRtl});
+      _lastIsRtl = isRtl;
     }
   }
 


### PR DESCRIPTION
# Pull Request: Fix RTL Layout Direction for iOS 26 Native TabBar

**FIX #98** (Assuming this is the next issue number)

## Description
This PR fixes the layout directionality for the native **iOS 26 Liquid Glass TabBar**. Previously, the tab bar remained in LTR (Left-to-Right) mode even when the Flutter app was set to an RTL locale (Arabic, Hebrew, etc.).

The fix involves passing the `TextDirection` through the platform channel and updating the native `UITabBar` and its container view's `semanticContentAttribute` on the Swift side.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI/UX improvement

## Related Issues
Closes #98 

## Changes Made
- **Platform Bridge:** Added `isRTL` boolean to the platform channel arguments for the navigation bar.
- **Native iOS (Swift):** Implemented `semanticContentAttribute` updates to force `forceRightToLeft` when the locale is RTL.
- **Flutter Core:** Integrated `Directionality.of(context)` check to automatically trigger the layout change during the widget build phase.

## Testing
- [x] Verified RTL mirroring on iOS 26+ Simulator/Device.
- [x] Verified LTR remains unaffected.
- [x] Tested seamless switching between Arabic and English locales.

## Visual Comparison (RTL Mode)

| Before (Broken LTR on iOS) | After (Correct RTL Mirroring) |
| :--- | :--- |
| <img width="376" alt="iOS RTL Broken" src="https://github.com/user-attachments/assets/b5b83914-c653-4c05-94f2-396cc7aa1863" /> | <img width="391" alt="iOS RTL Fixed" src="https://github.com/user-attachments/assets/e87afffe-ac67-4cd2-851b-9dd87d3ddac5" /> |

## Demo Code
No changes required for the end-user. The `AdaptiveNavigationDestination` now respects the ambient `Directionality`:

```dart
// This now mirrors automatically in RTL locales
return MaterialApp(
  locale: Locale('ar'), 
  home: Scaffold(
    bottomNavigationBar: AdaptiveNavigationBar(...),
  ),
);