### PR TITLE
feat: add flag to toggle bottom divider in AdaptiveListTile

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ if (selectedTime != null) {
 AdaptiveListTile(
   title: Text('Profile'),
   subtitle: Text('View your profile'),
-  showDivider: true, // Toggle bottom border (IOS only)
+  hideBottomDivider: false, // Hide bottom border, useful for last item (iOS only)
   onTap: () {
     // Handle tap
   },

--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ if (selectedTime != null) {
 AdaptiveListTile(
   title: Text('Profile'),
   subtitle: Text('View your profile'),
+  showDivider: true, // Toggle bottom border (IOS only)
   onTap: () {
     // Handle tap
   },

--- a/example/lib/pages/demos/list_tile_demo_page.dart
+++ b/example/lib/pages/demos/list_tile_demo_page.dart
@@ -54,6 +54,7 @@ class _ListTileDemoPageState extends State<ListTileDemoPage> {
                 },
               ),
               AdaptiveListTile(
+                hideBottomDivider: true,
                 title: const Text('Disabled List Tile'),
                 subtitle: const Text('This tile is not interactive'),
                 enabled: false,
@@ -115,6 +116,7 @@ class _ListTileDemoPageState extends State<ListTileDemoPage> {
                 },
               ),
               AdaptiveListTile(
+                hideBottomDivider: true,
                 leading: Icon(
                   PlatformInfo.isIOS
                       ? CupertinoIcons.bell
@@ -151,6 +153,7 @@ class _ListTileDemoPageState extends State<ListTileDemoPage> {
               ...List.generate(
                 3,
                 (index) => AdaptiveListTile(
+                  hideBottomDivider: index == 2,
                   leading: Container(
                     width: 40,
                     height: 40,
@@ -210,6 +213,7 @@ class _ListTileDemoPageState extends State<ListTileDemoPage> {
                 ),
               ),
               AdaptiveListTile(
+                hideBottomDivider: true,
                 title: const Text('Badge Notification'),
                 subtitle: const Text('3 unread messages'),
                 trailing: AdaptiveBadge(
@@ -331,7 +335,7 @@ class _ListTileDemoPageState extends State<ListTileDemoPage> {
           ),
         ),
         AdaptiveCard(
-          padding: EdgeInsets.zero,
+          padding: EdgeInsets.all(3),
           child: Column(children: children),
         ),
       ],

--- a/lib/src/widgets/adaptive_list_tile.dart
+++ b/lib/src/widgets/adaptive_list_tile.dart
@@ -18,6 +18,7 @@ class AdaptiveListTile extends StatelessWidget {
     this.onLongPress,
     this.enabled = true,
     this.selected = false,
+    this.showDivider = true,
     this.backgroundColor,
     this.padding,
   });
@@ -45,6 +46,9 @@ class AdaptiveListTile extends StatelessWidget {
 
   /// Whether this list tile is selected.
   final bool selected;
+
+  /// Whether the bottom divider should be shown.
+  final bool showDivider;
 
   /// The background color of the tile.
   final Color? backgroundColor;
@@ -78,14 +82,16 @@ class AdaptiveListTile extends StatelessWidget {
                 : (isDark
                       ? CupertinoColors.darkBackgroundGray
                       : CupertinoColors.white)),
-        border: Border(
-          bottom: BorderSide(
-            color: isDark
-                ? CupertinoColors.systemGrey4
-                : CupertinoColors.separator,
-            width: 0.5,
-          ),
-        ),
+        border: !showDivider
+            ? null
+            : Border(
+                bottom: BorderSide(
+                  color: isDark
+                      ? CupertinoColors.systemGrey4
+                      : CupertinoColors.separator,
+                  width: 0.5,
+                ),
+              ),
       ),
       child: Row(
         children: [

--- a/lib/src/widgets/adaptive_list_tile.dart
+++ b/lib/src/widgets/adaptive_list_tile.dart
@@ -18,7 +18,7 @@ class AdaptiveListTile extends StatelessWidget {
     this.onLongPress,
     this.enabled = true,
     this.selected = false,
-    this.showDivider = true,
+    this.hideBottomDivider = false,
     this.backgroundColor,
     this.padding,
   });
@@ -47,8 +47,9 @@ class AdaptiveListTile extends StatelessWidget {
   /// Whether this list tile is selected.
   final bool selected;
 
-  /// Whether the bottom divider should be shown.
-  final bool showDivider;
+  /// Whether to hide the bottom divider (iOS only).
+  /// Useful for the last tile in a grouped list to avoid a double border.
+  final bool hideBottomDivider;
 
   /// The background color of the tile.
   final Color? backgroundColor;
@@ -82,7 +83,7 @@ class AdaptiveListTile extends StatelessWidget {
                 : (isDark
                       ? CupertinoColors.darkBackgroundGray
                       : CupertinoColors.white)),
-        border: !showDivider
+        border: hideBottomDivider
             ? null
             : Border(
                 bottom: BorderSide(


### PR DESCRIPTION
## Description
I had the problem that I wanted to use a ListTile but remove the border on the last one as it looked weird. I couldn't see a way to do it so I thought it would make sense to add a flag. That's what this PR is about. 

## Type of Change
<!-- Please check the relevant option(s) -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement


## Changes Made
- Add a `showDivider` param to `AdaptiveListTile` that toggle the Border on IOS. Defaults to `true` to avoid breaking changes

## Testing

### Automated Tests ⚠️ **REQUIRED**
<!-- All PRs that add or modify functionality MUST include tests -->
- [ ] I have added unit/widget tests for my changes
- [ ] All new and existing tests pass locally (`flutter test`)
- [ ] Code analysis passes with no errors (`flutter analyze`)
- [ ] Code formatting is correct (`dart format`)
- [ ] Test coverage is adequate (>80% for new code)

### Manual Testing
<!-- Check all platforms where you've manually tested these changes -->
- [x ] iOS 26+ tested
- [ x] iOS <26 tested
- [ ] Android tested
- [ ] Web tested (if applicable)
- [ ] Tested in both light and dark mode
- [ ] Tested with different screen sizes
- [ ] Tested with accessibility features (large fonts, screen readers, etc.)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos demonstrating the changes -->

### Before
The last item has a border which looks weird with the card border
<img width="399" height="142" alt="image" src="https://github.com/user-attachments/assets/506c7f94-8c7c-4cd0-928a-02d5eaacc9ec" />

### After
#### IOS (showDivider: false)
<img width="401" height="147" alt="image" src="https://github.com/user-attachments/assets/b0a1bb38-d340-4198-a4fb-a086e3bb14fd" />

#### IOS (showDivider: true)
<img width="403" height="145" alt="image" src="https://github.com/user-attachments/assets/54cba94c-4c5a-45db-8b56-866697003181" />


## Checklist
<!-- Please check all that apply -->
- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ x ] I have checked that my code does not introduce any accessibility issues
- [ ] I have updated the CHANGELOG.md file (if applicable)
- [ ] I have updated version number in pubspec.yaml (if applicable)
- [ ] I have added examples to the example app (if adding new widgets)


## Demo Code
See README.md change
```
