### PR TITLE
Fix iOS 26 alert tint when cancel action is present without a primary action

### DIFF
--- a/ios/Classes/iOS26AlertDialogView.swift
+++ b/ios/Classes/iOS26AlertDialogView.swift
@@ -404,19 +404,6 @@ class iOS26AlertDialogView: NSObject, FlutterPlatformView {
 
         // Add actions
         var primaryAction: UIAlertAction?
-        var cancelAction: UIAlertAction?
-
-        // Determine preferred action
-        var preferredActionStyle: String?
-        for (index, _) in actionTitles.enumerated() {
-            let style = index < actionStyles.count ? actionStyles[index] : "defaultAction"
-
-            if style == "primary" && preferredActionStyle == nil {
-                preferredActionStyle = "primary"
-            } else if style == "cancel" && preferredActionStyle != "primary" {
-                preferredActionStyle = "cancel"
-            }
-        }
 
         for (index, actionTitle) in actionTitles.enumerated() {
             let style = index < actionStyles.count ? actionStyles[index] : "defaultAction"
@@ -511,24 +498,17 @@ class iOS26AlertDialogView: NSObject, FlutterPlatformView {
 
             action.isEnabled = enabled && style != "disabled"
             alert.addAction(action)
-
-            switch style {
-            case "cancel":
-                cancelAction = action
-            case "primary":
+            if style == "primary" {
                 primaryAction = action
-            default:
-                break
             }
         }
 
-        // Set preferred action
+        // Only promote explicit primary actions.
+        // A cancel action should remain neutral and must not force the
+        // alert tint to red when no primary action is present.
         if let action = primaryAction {
             alert.preferredAction = action
             alert.view.tintColor = UIColor.systemBlue
-        } else if let action = cancelAction {
-            alert.preferredAction = action
-            alert.view.tintColor = UIColor.systemRed
         }
 
         // Present the alert


### PR DESCRIPTION

This PR fixes an iOS 26 alert dialog styling issue in AdaptiveAlertDialog / IOS26AlertDialog.

## Description

When an alert included a cancel action but no primary action, the native iOS implementation promoted the cancel action to preferredAction and forced the alert tint to systemRed. That caused neutral cancel buttons to appear red in dialogs where the only styled action should have been the destructive one.

Example impact:
A dialog with:

Cancel as AlertActionStyle.cancel
Clear All as AlertActionStyle.destructive
would incorrectly render Cancel in red because the alert tint was being globally forced to red.

Root cause:
In ios/Classes/iOS26AlertDialogView.swift, the native alert code:

tracked both primaryAction and cancelAction
assigned preferredAction to the cancel action when no primary action existed
explicitly set alert.view.tintColor = UIColor.systemRed in that case
That behavior made a neutral cancel action inherit destructive-looking styling.

What changed:

Removed the logic that promotes cancel to the preferred action.
Removed the fallback that forces the alert tint to red when no primary action is present.
Kept preferred action behavior only for explicit primary actions.
New behavior:

primary actions are still promoted and tinted as before.
cancel actions remain neutral when no primary action exists.
destructive actions remain destructive without incorrectly affecting neutral actions.

Why this is the right fix:
Using primary as a workaround for destructive actions would avoid the tint issue, but it would be semantically incorrect. primary and destructive mean different things in native alerts. This fix preserves the intended action semantics and corrects the package behavior instead of requiring app-level workarounds.

## Type of Change
<!-- Please check the relevant option(s) -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
<!-- Link any related issues here -->
Closes #

## Changes Made
<!-- List the specific changes made in this PR -->
-
-
-

## Testing

### Automated Tests ⚠️ **REQUIRED**
<!-- All PRs that add or modify functionality MUST include tests -->
- [ ] I have added unit/widget tests for my changes
- [ ] All new and existing tests pass locally (`flutter test`)
- [ ] Code analysis passes with no errors (`flutter analyze`)
- [ ] Code formatting is correct (`dart format`)
- [ ] Test coverage is adequate (>80% for new code)

### Manual Testing
<!-- Check all platforms where you've manually tested these changes -->
- [x] iOS 26+ tested
- [x] iOS <26 tested
- [x] Android tested
- [ ] Web tested (if applicable)
- [ ] Tested in both light and dark mode
- [ ] Tested with different screen sizes
- [ ] Tested with accessibility features (large fonts, screen readers, etc.)

## Screenshots/Videos
<!-- If applicable, add screenshots or videos demonstrating the changes -->

### Before
<!-- Screenshots or description of behavior before changes -->

### After
<!-- Screenshots or description of behavior after changes -->

## Checklist
<!-- Please check all that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that my code does not introduce any accessibility issues
- [ ] I have updated the CHANGELOG.md file (if applicable)
- [ ] I have updated version number in pubspec.yaml (if applicable)
- [ ] I have added examples to the example app (if adding new widgets)

## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here and provide migration guide -->

## Additional Notes
<!-- Add any additional information that reviewers should know -->

## Demo Code
<!-- If applicable, provide example code showing how to use the new feature -->
```dart
// Example usage
```
