### PR TITLE
Remove empty space for simple message dialogs

### DIFF
--- a/lib/src/widgets/adaptive_alert_dialog.dart
+++ b/lib/src/widgets/adaptive_alert_dialog.dart
@@ -90,19 +90,26 @@ class AdaptiveAlertDialog {
         context: context,
         builder: (context) {
           Widget? contentWidget;
+          final hasLegacyIcon =
+              icon != null && icon is IconData && iconSize != null;
+          final hasOtpCode = oneTimeCode != null;
+          final hasContentBelowMessage = hasOtpCode;
+          final hasScrollableLegacyContent =
+              hasLegacyIcon || hasOtpCode || message != null;
 
           // Build custom content if icon or OTP is present
-          if (icon != null || oneTimeCode != null || message != null) {
+          if (hasScrollableLegacyContent) {
             contentWidget = ConstrainedBox(
-              constraints: const BoxConstraints(minHeight: 60, maxHeight: 300),
+              constraints: BoxConstraints(
+                minHeight: hasContentBelowMessage ? 60 : 0,
+                maxHeight: 300,
+              ),
               child: SingleChildScrollView(
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    if (icon != null &&
-                        icon is IconData &&
-                        iconSize != null) ...[
+                    if (hasLegacyIcon) ...[
                       Icon(
                         icon,
                         size: iconSize,
@@ -116,9 +123,9 @@ class AdaptiveAlertDialog {
                         textAlign: TextAlign.center,
                         style: const TextStyle(fontSize: 13),
                       ),
-                      const SizedBox(height: 12),
+                      if (hasContentBelowMessage) const SizedBox(height: 12),
                     ],
-                    if (oneTimeCode != null) ...[
+                    if (hasOtpCode) ...[
                       Container(
                         padding: const EdgeInsets.symmetric(
                           horizontal: 16,
@@ -336,6 +343,11 @@ class AdaptiveAlertDialog {
       builder: (context) {
         // Build custom content if icon, OTP, or textfield is present
         Widget? contentWidget;
+        final hasMaterialIcon =
+            icon != null && icon is IconData && iconSize != null;
+        final hasOtpCode = oneTimeCode != null;
+        final hasInput = input != null;
+        final hasContentBelowMessage = hasOtpCode || hasInput;
         if (icon != null ||
             oneTimeCode != null ||
             message != null ||
@@ -343,15 +355,15 @@ class AdaptiveAlertDialog {
           contentWidget = Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              if (icon != null && icon is IconData && iconSize != null) ...[
+              if (hasMaterialIcon) ...[
                 Icon(icon, size: iconSize, color: iconColor ?? Colors.blue),
                 const SizedBox(height: 12),
               ],
               if (message != null) ...[
                 Text(message, textAlign: TextAlign.center),
-                const SizedBox(height: 16),
+                if (hasContentBelowMessage) const SizedBox(height: 16),
               ],
-              if (oneTimeCode != null) ...[
+              if (hasOtpCode) ...[
                 Container(
                   padding: const EdgeInsets.symmetric(
                     horizontal: 20,


### PR DESCRIPTION
## Description
This PR fixes unnecessary empty vertical space in `AdaptiveAlertDialog` on Android and iOS <26.

Simple message-only dialogs were rendering with a large gap between the message text and the action buttons because the legacy dialog builders always inserted trailing spacer height after the message. On iOS <26, the builder also enforced a minimum content height even when there was no content below the message.

This change updates the legacy iOS and Android dialog builders so spacing after the message is only added when there is actual content following it, such as an OTP block or text input. For plain message-only dialogs, the extra empty space is no longer rendered.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
Closes #

## Changes Made
- Removed unconditional trailing spacing after dialog messages in the legacy iOS alert builder
- Removed unconditional trailing spacing after dialog messages in the Android/Material alert builder
- Adjusted the legacy iOS minimum content height so simple message-only dialogs do not reserve extra empty vertical space

## Testing

### Automated Tests ⚠️ **REQUIRED**
- [ ] I have added unit/widget tests for my changes
- [ ] All new and existing tests pass locally (`flutter test`)
- [x] Code analysis passes with no errors (`flutter analyze`)
- [x] Code formatting is correct (`dart format`)
- [ ] Test coverage is adequate (>80% for new code)

### Manual Testing
- [x] iOS 26+ tested
- [x] iOS <26 tested
- [x] Android tested
- [ ] Web tested (if applicable)
- [ ] Tested in both light and dark mode
- [ ] Tested with different screen sizes
- [ ] Tested with accessibility features (large fonts, screen readers, etc.)

## Screenshots/Videos

### Before
- Message-only dialogs on Android and iOS <26 showed a large empty gap between the dialog text and the action buttons

### After
- Message-only dialogs on Android and iOS <26 no longer include unnecessary empty space below the message

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that my code does not introduce any accessibility issues
- [ ] I have updated the CHANGELOG.md file (if applicable)
- [ ] I have updated version number in pubspec.yaml (if applicable)
- [ ] I have added examples to the example app (if adding new widgets)

## Breaking Changes
This PR does not introduce breaking changes.

## Additional Notes
This change only affects dialogs where the message is the final content block. Dialogs that include additional content after the message, such as OTP code blocks or text input fields, keep their intended spacing.

Validation performed locally:
- `dart format lib/src/widgets/adaptive_alert_dialog.dart`
- `flutter analyze lib/src/widgets/adaptive_alert_dialog.dart`

## Demo Code
```dart
await AdaptiveAlertDialog.show(
  context: context,
  title: 'Logout',
  message: 'Are you sure you want to logout?',
  actions: [
    AlertAction(
      title: 'Cancel',
      style: AlertActionStyle.cancel,
      onPressed: () {},
    ),
    AlertAction(
      title: 'Logout',
      style: AlertActionStyle.defaultAction,
      onPressed: () {},
    ),
  ],
);
