### PR TITLE
Fix iOS segmented control theming on iOS 26+ and remove overflow on older iOS versions

### DIFF
--- a/ios/Classes/iOS26SegmentedControlView.swift
+++ b/ios/Classes/iOS26SegmentedControlView.swift
@@ -35,6 +35,7 @@ class iOS26SegmentedControlView: NSObject, FlutterPlatformView {
     private var channel: FlutterMethodChannel
     private var controlId: Int
     private var isDark: Bool = false
+    private var textColor: UIColor?
 
     init(
         frame: CGRect,
@@ -123,6 +124,10 @@ class iOS26SegmentedControlView: NSObject, FlutterPlatformView {
                 segmentedControl.selectedSegmentTintColor = tintColor
             }
 
+            if let textColorValue = config["textColor"] as? Int {
+                textColor = colorFromARGB(textColorValue)
+            }
+
             // Set selected index
             if let selectedIndex = config["selectedIndex"] as? Int, selectedIndex >= 0 {
                 segmentedControl.selectedSegmentIndex = selectedIndex
@@ -135,6 +140,8 @@ class iOS26SegmentedControlView: NSObject, FlutterPlatformView {
                 }
             }
         }
+
+        applyTheme()
 
         _view.addSubview(segmentedControl)
         NSLayoutConstraint.activate([
@@ -153,6 +160,18 @@ class iOS26SegmentedControlView: NSObject, FlutterPlatformView {
         let g = CGFloat((argb >> 8) & 0xFF) / 255.0
         let b = CGFloat(argb & 0xFF) / 255.0
         return UIColor(red: r, green: g, blue: b, alpha: a)
+    }
+
+    private func applyTheme() {
+        let normalTextColor = textColor ?? .label
+        segmentedControl.setTitleTextAttributes(
+            [.foregroundColor: normalTextColor],
+            for: .normal
+        )
+        segmentedControl.setTitleTextAttributes(
+            [.foregroundColor: normalTextColor.withAlphaComponent(0.5)],
+            for: .disabled
+        )
     }
 
     @objc private func segmentChanged() {
@@ -176,12 +195,19 @@ class iOS26SegmentedControlView: NSObject, FlutterPlatformView {
             result(nil)
 
         case "setBrightness":
-            if let args = call.arguments as? [String: Any],
-               let dark = args["isDark"] as? Bool {
-                isDark = dark
-                if #available(iOS 13.0, *) {
-                    _view.overrideUserInterfaceStyle = dark ? .dark : .light
+            if let args = call.arguments as? [String: Any] {
+                if let dark = args["isDark"] as? Bool {
+                    isDark = dark
+                    if #available(iOS 13.0, *) {
+                        _view.overrideUserInterfaceStyle = dark ? .dark : .light
+                    }
                 }
+
+                if let textColorValue = args["textColor"] as? Int {
+                    textColor = colorFromARGB(textColorValue)
+                }
+
+                applyTheme()
             }
             result(nil)
 

--- a/lib/src/widgets/adaptive_segmented_control.dart
+++ b/lib/src/widgets/adaptive_segmented_control.dart
@@ -126,11 +126,16 @@ class AdaptiveSegmentedControl extends StatelessWidget {
       },
     );
 
+    control = ConstrainedBox(
+      constraints: BoxConstraints(minHeight: height),
+      child: control,
+    );
+
     if (shrinkWrap) {
       control = Center(child: IntrinsicWidth(child: control));
     }
 
-    return SizedBox(height: height, child: control);
+    return control;
   }
 
   Widget _buildMaterialSegmentedButton(BuildContext context) {

--- a/lib/src/widgets/ios26/ios26_segmented_control.dart
+++ b/lib/src/widgets/ios26/ios26_segmented_control.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 /// Native iOS 26 segmented control implementation using platform views
@@ -59,6 +60,7 @@ class _IOS26SegmentedControlState extends State<IOS26SegmentedControl> {
   late final int _id;
   late final MethodChannel _channel;
   bool? _lastIsDark;
+  int? _lastTextColor;
 
   @override
   void initState() {
@@ -73,7 +75,7 @@ class _IOS26SegmentedControlState extends State<IOS26SegmentedControl> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _syncBrightnessIfNeeded();
+    _syncThemeIfNeeded();
   }
 
   @override
@@ -82,12 +84,24 @@ class _IOS26SegmentedControlState extends State<IOS26SegmentedControl> {
     super.dispose();
   }
 
-  Future<void> _syncBrightnessIfNeeded() async {
-    final isDark = MediaQuery.platformBrightnessOf(context) == Brightness.dark;
-    if (_lastIsDark != isDark) {
+  Brightness _effectiveBrightness() {
+    return CupertinoTheme.of(context).brightness ??
+        Theme.of(context).brightness;
+  }
+
+  Future<void> _syncThemeIfNeeded() async {
+    final isDark = _effectiveBrightness() == Brightness.dark;
+    final themeParams = _buildThemeParams();
+    final textColor = themeParams['textColor'] as int;
+
+    if (_lastIsDark != isDark || _lastTextColor != textColor) {
       try {
-        await _channel.invokeMethod('setBrightness', {'isDark': isDark});
+        await _channel.invokeMethod('setBrightness', {
+          'isDark': isDark,
+          ...themeParams,
+        });
         _lastIsDark = isDark;
+        _lastTextColor = textColor;
       } catch (e) {
         // Ignore errors if platform view is not yet ready
       }
@@ -125,9 +139,25 @@ class _IOS26SegmentedControlState extends State<IOS26SegmentedControl> {
         ((color.b * 255.0).round() & 0xff);
   }
 
+  Map<String, dynamic> _buildThemeParams() {
+    final cupertinoTheme = CupertinoTheme.of(context);
+    final brightness = _effectiveBrightness();
+
+    final baseTextStyle = DefaultTextStyle.of(context).style;
+    final themeTextStyle = cupertinoTheme.textTheme.textStyle;
+
+    final effectiveTextColor =
+        baseTextStyle.color ??
+        themeTextStyle.color ??
+        (brightness == Brightness.dark
+            ? CupertinoColors.white
+            : CupertinoColors.black);
+
+    return <String, dynamic>{'textColor': _colorToARGB(effectiveTextColor)};
+  }
+
   Map<String, dynamic> _buildCreationParams() {
-    final bool isDark =
-        MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    final bool isDark = _effectiveBrightness() == Brightness.dark;
 
     final params = <String, dynamic>{
       'id': _id,
@@ -135,6 +165,7 @@ class _IOS26SegmentedControlState extends State<IOS26SegmentedControl> {
       'selectedIndex': widget.selectedIndex,
       'enabled': widget.enabled,
       'isDark': isDark,
+      ..._buildThemeParams(),
     };
 
     // Add SF symbols if provided


### PR DESCRIPTION
## Description
This PR fixes two issues in `AdaptiveSegmentedControl` on iOS.

On iOS 26+, the native segmented control was not updating inactive label colors to match the active app theme, so unselected segments could remain visually incorrect in dark mode or when using a custom Cupertino theme.

On older iOS versions, the Cupertino segmented control was wrapped in a fixed-height box, which could clip the control and produce small vertical overflow errors with certain text metrics.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
Closes #

## Changes Made
- Bridge the effective Flutter theme text color into the iOS 26 native segmented control
- Apply and refresh native title text attributes for inactive segments when theme/brightness changes
- Replace the fixed-height Cupertino wrapper with a minimum-height constraint to avoid overflow on older iOS versions

## Testing

### Automated Tests ⚠️ **REQUIRED**
- [ ] I have added unit/widget tests for my changes
- [x] All new and existing tests pass locally (`flutter test`)
- [x] Code analysis passes with no errors (`flutter analyze`)
- [x] Code formatting is correct (`dart format`)
- [ ] Test coverage is adequate (>80% for new code)

### Manual Testing
- [x] iOS 26+ tested
- [x] iOS <26 tested
- [x] Android tested
- [ ] Web tested (if applicable)
- [x] Tested in both light and dark mode
- [ ] Tested with different screen sizes
- [ ] Tested with accessibility features (large fonts, screen readers, etc.)

## Screenshots/Videos

on iOS 18
<img width="752" height="112" alt="image" src="https://github.com/user-attachments/assets/12aa8097-1953-4923-bbe0-fd82922d5093" />

on iOS 26
<img width="732" height="94" alt="image" src="https://github.com/user-attachments/assets/d274bb16-54cb-456f-8047-2ea305a41184" />

### Before
- On iOS 26+, inactive segmented control labels did not follow the active app theme
- On older iOS versions, the control could overflow vertically by a few pixels

### After
- On iOS 26+, inactive labels follow the effective app theme correctly
- On older iOS versions, the control sizes without overflow

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that my code does not introduce any accessibility issues
- [ ] I have updated the CHANGELOG.md file (if applicable)
- [ ] I have updated version number in pubspec.yaml (if applicable)
- [ ] I have added examples to the example app (if adding new widgets)

## Breaking Changes
None.

## Additional Notes
The iOS 26 fix is implemented in the native `UISegmentedControl` bridge, since Flutter-side Cupertino theme changes do not automatically propagate into `UiKitView` content.

## Demo Code
```dart
AdaptiveSegmentedControl(
  labels: const ['Light', 'Dark', 'System'],
  selectedIndex: 1,
  onValueChanged: (index) {},
)
