### PR TITLE
add dynamic image in iOS 26 Liquid Glass navigation bar

### DIFF
--- a/ios/Classes/iOS26TabBarPlatformView.swift
+++ b/ios/Classes/iOS26TabBarPlatformView.swift
@@ -10,8 +10,13 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
     private var currentSymbols: [String] = []
     private var currentAssetIcons: [String] = []
     private var currentSelectedAssetIcons: [String] = []
+    private var currentFileIcons: [String] = []
+    private var currentSelectedFileIcons: [String] = []
+    private var currentNetworkIcons: [String] = []
+    private var currentSelectedNetworkIcons: [String] = []
     private var currentSearchFlags: [Bool] = []
     private var currentBadgeCounts: [Int?] = []
+    private let imageCache = NSCache<NSString, UIImage>()
 
     init(frame: CGRect, viewId: Int64, args: Any?, messenger: FlutterBinaryMessenger) {
         self.channel = FlutterMethodChannel(
@@ -24,6 +29,10 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
         var symbols: [String] = []
         var assetIcons: [String] = []
         var selectedAssetIcons: [String] = []
+        var fileIcons: [String] = []
+        var selectedFileIcons: [String] = []
+        var networkIcons: [String] = []
+        var selectedNetworkIcons: [String] = []
         var searchFlags: [Bool] = []
         var badgeCounts: [Int?] = []
         var spacerFlags: [Bool] = []
@@ -42,6 +51,10 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
             symbols = (dict["sfSymbols"] as? [String]) ?? []
             assetIcons = (dict["assetIcons"] as? [String]) ?? []
             selectedAssetIcons = (dict["selectedAssetIcons"] as? [String]) ?? []
+            fileIcons = (dict["fileIcons"] as? [String]) ?? []
+            selectedFileIcons = (dict["selectedFileIcons"] as? [String]) ?? []
+            networkIcons = (dict["networkIcons"] as? [String]) ?? []
+            selectedNetworkIcons = (dict["selectedNetworkIcons"] as? [String]) ?? []
             searchFlags = (dict["searchFlags"] as? [Bool]) ?? []
             spacerFlags = (dict["spacerFlags"] as? [Bool]) ?? []
             if let badgeData = dict["badgeCounts"] as? [NSNumber?] {
@@ -168,58 +181,62 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                     var image: UIImage? = nil
                     var selectedImage: UIImage? = nil
 
-                    if i < assetIcons.count && !assetIcons[i].isEmpty {
-                        let assetName = assetIcons[i]
-                        let key = FlutterDartProject.lookupKey(forAsset: assetName)
-                        let rawImageOriginal = UIImage(named: key)
-                        let rawImage = rawImageOriginal != nil ? self.resizeImage(image: rawImageOriginal!) : nil
-                        
-                        var selRawImage = rawImage
-                        if i < selectedAssetIcons.count && !selectedAssetIcons[i].isEmpty {
-                            let selKey = FlutterDartProject.lookupKey(forAsset: selectedAssetIcons[i])
-                            let selRawOriginal = UIImage(named: selKey)
-                            if selRawOriginal != nil {
-                                selRawImage = self.resizeImage(image: selRawOriginal!)
-                            }
-                        }
-                        
-                        if #available(iOS 26.0, *) {
-                            if let unselTint = unselectedTint {
-                                image = rawImage?.withTintColor(unselTint, renderingMode: .alwaysOriginal)
-                            } else {
-                                image = rawImage?.withRenderingMode(.alwaysTemplate)
-                            }
-                            selectedImage = selRawImage?.withRenderingMode(.alwaysTemplate)
-                        } else {
-                            image = rawImage
-                            selectedImage = selRawImage
-                        }
-                    } else if i < symbols.count && !symbols[i].isEmpty {
-                        // iOS 26+: Use different rendering modes for selected/unselected
-                        if #available(iOS 26.0, *) {
-                            // Unselected: Only apply custom color if unselectedTint is provided
-                            if let unselTint = unselectedTint {
-                                // Create colored image for unselected state
-                                if let originalImage = UIImage(systemName: symbols[i]) {
-                                    image = originalImage.withTintColor(unselTint, renderingMode: .alwaysOriginal)
-                                }
-                            } else {
-                                // No custom color - use template mode to respect theme
-                                image = UIImage(systemName: symbols[i])?.withRenderingMode(.alwaysTemplate)
-                            }
-
-                            // Selected: Use template rendering so tintColor applies
-                            selectedImage = UIImage(systemName: symbols[i])?.withRenderingMode(.alwaysTemplate)
-                        } else {
-                            // iOS <26: Use default behavior
-                            image = UIImage(systemName: symbols[i])
-                            selectedImage = image
-                        }
-                    }
-
-                    // Create item with title
-                    item = UITabBarItem(title: title ?? "Tab \(i+1)", image: image, selectedImage: selectedImage)
+                    item = UITabBarItem(title: title ?? "Tab \(i+1)", image: nil, selectedImage: nil)
                     item.tag = i
+
+                    if !self.configureRuntimeImages(for: item, index: i) {
+                        if i < assetIcons.count && !assetIcons[i].isEmpty {
+                            let assetName = assetIcons[i]
+                            let key = FlutterDartProject.lookupKey(forAsset: assetName)
+                            let rawImageOriginal = UIImage(named: key)
+                            let rawImage = rawImageOriginal != nil ? self.resizeImage(image: rawImageOriginal!) : nil
+
+                            var selRawImage = rawImage
+                            if i < selectedAssetIcons.count && !selectedAssetIcons[i].isEmpty {
+                                let selKey = FlutterDartProject.lookupKey(forAsset: selectedAssetIcons[i])
+                                let selRawOriginal = UIImage(named: selKey)
+                                if selRawOriginal != nil {
+                                    selRawImage = self.resizeImage(image: selRawOriginal!)
+                                }
+                            }
+
+                            if #available(iOS 26.0, *) {
+                                if let unselTint = unselectedTint {
+                                    image = rawImage?.withTintColor(unselTint, renderingMode: .alwaysOriginal)
+                                } else {
+                                    image = rawImage?.withRenderingMode(.alwaysTemplate)
+                                }
+                                selectedImage = selRawImage?.withRenderingMode(.alwaysTemplate)
+                            } else {
+                                image = rawImage
+                                selectedImage = selRawImage
+                            }
+                        } else if i < symbols.count && !symbols[i].isEmpty {
+                            // iOS 26+: Use different rendering modes for selected/unselected
+                            if #available(iOS 26.0, *) {
+                                // Unselected: Only apply custom color if unselectedTint is provided
+                                if let unselTint = unselectedTint {
+                                    // Create colored image for unselected state
+                                    if let originalImage = UIImage(systemName: symbols[i]) {
+                                        image = originalImage.withTintColor(unselTint, renderingMode: .alwaysOriginal)
+                                    }
+                                } else {
+                                    // No custom color - use template mode to respect theme
+                                    image = UIImage(systemName: symbols[i])?.withRenderingMode(.alwaysTemplate)
+                                }
+
+                                // Selected: Use template rendering so tintColor applies
+                                selectedImage = UIImage(systemName: symbols[i])?.withRenderingMode(.alwaysTemplate)
+                            } else {
+                                // iOS <26: Use default behavior
+                                image = UIImage(systemName: symbols[i])
+                                selectedImage = image
+                            }
+                        }
+
+                        item.image = image
+                        item.selectedImage = selectedImage
+                    }
                 }
 
                 // Set badge value if provided
@@ -234,7 +251,10 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
             return items
         }
 
-        let count = max(labels.count, symbols.count)
+        let count = max(
+            max(labels.count, symbols.count),
+            max(max(assetIcons.count, fileIcons.count), networkIcons.count)
+        )
         bar.items = buildItems(0..<count)
 
         // Note: spacerFlags are received but not yet implemented for UITabBar
@@ -259,9 +279,12 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
         self.currentSymbols = symbols
         self.currentAssetIcons = assetIcons
         self.currentSelectedAssetIcons = selectedAssetIcons
+        self.currentFileIcons = fileIcons
+        self.currentSelectedFileIcons = selectedFileIcons
+        self.currentNetworkIcons = networkIcons
+        self.currentSelectedNetworkIcons = selectedNetworkIcons
         self.currentSearchFlags = searchFlags
         self.currentBadgeCounts = badgeCounts
-
         // Apply minimize behavior if available
         self.applyMinimizeBehavior()
 
@@ -304,6 +327,10 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
 
             let assetIcons = (args["assetIcons"] as? [String]) ?? []
             let selectedAssetIcons = (args["selectedAssetIcons"] as? [String]) ?? []
+            let fileIcons = (args["fileIcons"] as? [String]) ?? []
+            let selectedFileIcons = (args["selectedFileIcons"] as? [String]) ?? []
+            let networkIcons = (args["networkIcons"] as? [String]) ?? []
+            let selectedNetworkIcons = (args["selectedNetworkIcons"] as? [String]) ?? []
             let searchFlags = (args["searchFlags"] as? [Bool]) ?? []
             let selectedIndex = (args["selectedIndex"] as? NSNumber)?.intValue ?? 0
             var badgeCounts: [Int?] = []
@@ -315,13 +342,18 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
             self.currentSymbols = symbols
             self.currentAssetIcons = assetIcons
             self.currentSelectedAssetIcons = selectedAssetIcons
+            self.currentFileIcons = fileIcons
+            self.currentSelectedFileIcons = selectedFileIcons
+            self.currentNetworkIcons = networkIcons
+            self.currentSelectedNetworkIcons = selectedNetworkIcons
             self.currentSearchFlags = searchFlags
             self.currentBadgeCounts = badgeCounts
 
-            let maxCount = max(labels.count, symbols.count)
-            let count = max(maxCount, assetIcons.count)
+            let count = max(
+                max(labels.count, symbols.count),
+                max(max(assetIcons.count, fileIcons.count), networkIcons.count)
+            )
 
-            // Reuse the same buildItems function with rendering mode logic
             let buildItems: (Range<Int>) -> [UITabBarItem] = { range in
                 var items: [UITabBarItem] = []
                 for i in range {
@@ -348,61 +380,65 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                         var image: UIImage? = nil
                         var selectedImage: UIImage? = nil
 
-                        if i < assetIcons.count && !assetIcons[i].isEmpty {
-                            let assetName = assetIcons[i]
-                            let key = FlutterDartProject.lookupKey(forAsset: assetName)
-                            let rawImageOriginal = UIImage(named: key)
-                            let rawImage = rawImageOriginal != nil ? self.resizeImage(image: rawImageOriginal!) : nil
-                            
-                            var selRawImage = rawImage
-                            if i < selectedAssetIcons.count && !selectedAssetIcons[i].isEmpty {
-                                let selKey = FlutterDartProject.lookupKey(forAsset: selectedAssetIcons[i])
-                                let selRawOriginal = UIImage(named: selKey)
-                                if selRawOriginal != nil {
-                                    selRawImage = self.resizeImage(image: selRawOriginal!)
-                                }
-                            }
-                            
-                            if #available(iOS 26.0, *) {
-                                let unselTint = self.tabBar?.unselectedItemTintColor
-                                if let unselTint = unselTint {
-                                    image = rawImage?.withTintColor(unselTint, renderingMode: .alwaysOriginal)
-                                } else {
-                                    image = rawImage?.withRenderingMode(.alwaysTemplate)
-                                }
-                                selectedImage = selRawImage?.withRenderingMode(.alwaysTemplate)
-                            } else {
-                                image = rawImage
-                                selectedImage = selRawImage
-                            }
-                        } else if i < symbols.count && !symbols[i].isEmpty {
-                            // iOS 26+: Use different rendering modes for selected/unselected
-                            if #available(iOS 26.0, *) {
-                                // Get current unselected color from tab bar
-                                let unselTint = self.tabBar?.unselectedItemTintColor
-
-                                // Unselected: Only apply custom color if unselectedTint is set
-                                if let unselTint = unselTint {
-                                    if let originalImage = UIImage(systemName: symbols[i]) {
-                                        image = originalImage.withTintColor(unselTint, renderingMode: .alwaysOriginal)
-                                    }
-                                } else {
-                                    // No custom color - use template mode to respect theme
-                                    image = UIImage(systemName: symbols[i])?.withRenderingMode(.alwaysTemplate)
-                                }
-
-                                // Selected: Use template rendering so tintColor applies
-                                selectedImage = UIImage(systemName: symbols[i])?.withRenderingMode(.alwaysTemplate)
-                            } else {
-                                // iOS <26: Use default behavior
-                                image = UIImage(systemName: symbols[i])
-                                selectedImage = image
-                            }
-                        }
-
-                        // Create item with title
-                        item = UITabBarItem(title: title ?? "Tab \(i+1)", image: image, selectedImage: selectedImage)
+                        item = UITabBarItem(title: title ?? "Tab \(i+1)", image: nil, selectedImage: nil)
                         item.tag = i
+
+                        if !self.configureRuntimeImages(for: item, index: i) {
+                            if i < assetIcons.count && !assetIcons[i].isEmpty {
+                                let assetName = assetIcons[i]
+                                let key = FlutterDartProject.lookupKey(forAsset: assetName)
+                                let rawImageOriginal = UIImage(named: key)
+                                let rawImage = rawImageOriginal != nil ? self.resizeImage(image: rawImageOriginal!) : nil
+
+                                var selRawImage = rawImage
+                                if i < selectedAssetIcons.count && !selectedAssetIcons[i].isEmpty {
+                                    let selKey = FlutterDartProject.lookupKey(forAsset: selectedAssetIcons[i])
+                                    let selRawOriginal = UIImage(named: selKey)
+                                    if selRawOriginal != nil {
+                                        selRawImage = self.resizeImage(image: selRawOriginal!)
+                                    }
+                                }
+
+                                if #available(iOS 26.0, *) {
+                                    let unselTint = self.tabBar?.unselectedItemTintColor
+                                    if let unselTint = unselTint {
+                                        image = rawImage?.withTintColor(unselTint, renderingMode: .alwaysOriginal)
+                                    } else {
+                                        image = rawImage?.withRenderingMode(.alwaysTemplate)
+                                    }
+                                    selectedImage = selRawImage?.withRenderingMode(.alwaysTemplate)
+                                } else {
+                                    image = rawImage
+                                    selectedImage = selRawImage
+                                }
+                            } else if i < symbols.count && !symbols[i].isEmpty {
+                                // iOS 26+: Use different rendering modes for selected/unselected
+                                if #available(iOS 26.0, *) {
+                                    // Get current unselected color from tab bar
+                                    let unselTint = self.tabBar?.unselectedItemTintColor
+
+                                    // Unselected: Only apply custom color if unselectedTint is set
+                                    if let unselTint = unselTint {
+                                        if let originalImage = UIImage(systemName: symbols[i]) {
+                                            image = originalImage.withTintColor(unselTint, renderingMode: .alwaysOriginal)
+                                        }
+                                    } else {
+                                        // No custom color - use template mode to respect theme
+                                        image = UIImage(systemName: symbols[i])?.withRenderingMode(.alwaysTemplate)
+                                    }
+
+                                    // Selected: Use template rendering so tintColor applies
+                                    selectedImage = UIImage(systemName: symbols[i])?.withRenderingMode(.alwaysTemplate)
+                                } else {
+                                    // iOS <26: Use default behavior
+                                    image = UIImage(systemName: symbols[i])
+                                    selectedImage = image
+                                }
+                            }
+
+                            item.image = image
+                            item.selectedImage = selectedImage
+                        }
                     }
 
                     // Set badge value if provided
@@ -551,15 +587,17 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
         guard let bar = self.tabBar else { return }
 
         let currentSelectedIndex = bar.items?.firstIndex { $0 == bar.selectedItem } ?? 0
-        let unselTint = bar.unselectedItemTintColor
 
         // Rebuild items with new colors
         var items: [UITabBarItem] = []
-        for i in 0..<currentLabels.count {
-            let title = currentLabels[i]
+        let itemCount = max(
+            max(currentLabels.count, currentSymbols.count),
+            max(max(currentAssetIcons.count, currentFileIcons.count), currentNetworkIcons.count)
+        )
+        for i in 0..<itemCount {
+            let title = i < currentLabels.count ? currentLabels[i] : nil
             let isSearch = (i < currentSearchFlags.count) && currentSearchFlags[i]
             let badgeCount = (i < currentBadgeCounts.count) ? currentBadgeCounts[i] : nil
-
             let item: UITabBarItem
 
             if isSearch {
@@ -574,68 +612,71 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                 var image: UIImage? = nil
                 var selectedImage: UIImage? = nil
 
-                if i < currentAssetIcons.count && !currentAssetIcons[i].isEmpty {
-                    if #available(iOS 26.0, *) {
-                        let key = FlutterDartProject.lookupKey(forAsset: currentAssetIcons[i])
-                        let rawImageOriginal = UIImage(named: key)
-                        let rawImage = rawImageOriginal != nil ? self.resizeImage(image: rawImageOriginal!) : nil
-                        
-                        var selRawImage = rawImage
-                        if i < currentSelectedAssetIcons.count && !currentSelectedAssetIcons[i].isEmpty {
-                            let selKey = FlutterDartProject.lookupKey(forAsset: currentSelectedAssetIcons[i])
-                            let selRawOriginal = UIImage(named: selKey)
-                            if selRawOriginal != nil {
-                                selRawImage = self.resizeImage(image: selRawOriginal!)
+                item = UITabBarItem(title: title, image: nil, selectedImage: nil)
+                item.tag = i
+
+                if !configureRuntimeImages(for: item, index: i) {
+                    if i < currentAssetIcons.count && !currentAssetIcons[i].isEmpty {
+                        if #available(iOS 26.0, *) {
+                            let key = FlutterDartProject.lookupKey(forAsset: currentAssetIcons[i])
+                            let rawImageOriginal = UIImage(named: key)
+                            let rawImage = rawImageOriginal != nil ? self.resizeImage(image: rawImageOriginal!) : nil
+
+                            var selRawImage = rawImage
+                            if i < currentSelectedAssetIcons.count && !currentSelectedAssetIcons[i].isEmpty {
+                                let selKey = FlutterDartProject.lookupKey(forAsset: currentSelectedAssetIcons[i])
+                                let selRawOriginal = UIImage(named: selKey)
+                                if selRawOriginal != nil {
+                                    selRawImage = self.resizeImage(image: selRawOriginal!)
+                                }
                             }
-                        }
-                        
-                        if let unselTint = unselTint {
-                            image = rawImage?.withTintColor(unselTint, renderingMode: .alwaysOriginal)
+
+                            if let unselTint = bar.unselectedItemTintColor {
+                                image = rawImage?.withTintColor(unselTint, renderingMode: .alwaysOriginal)
+                            } else {
+                                image = rawImage?.withRenderingMode(.alwaysTemplate)
+                            }
+                            selectedImage = selRawImage?.withRenderingMode(.alwaysTemplate)
                         } else {
-                            image = rawImage?.withRenderingMode(.alwaysTemplate)
-                        }
-                        selectedImage = selRawImage?.withRenderingMode(.alwaysTemplate)
-                    } else {
-                        let key = FlutterDartProject.lookupKey(forAsset: currentAssetIcons[i])
-                        let rawImageOriginal = UIImage(named: key)
-                        image = rawImageOriginal != nil ? self.resizeImage(image: rawImageOriginal!) : nil
-                        
-                        if i < currentSelectedAssetIcons.count && !currentSelectedAssetIcons[i].isEmpty {
-                            let selKey = FlutterDartProject.lookupKey(forAsset: currentSelectedAssetIcons[i])
-                            let selRawOriginal = UIImage(named: selKey)
-                            if selRawOriginal != nil {
-                                selectedImage = self.resizeImage(image: selRawOriginal!)
+                            let key = FlutterDartProject.lookupKey(forAsset: currentAssetIcons[i])
+                            let rawImageOriginal = UIImage(named: key)
+                            image = rawImageOriginal != nil ? self.resizeImage(image: rawImageOriginal!) : nil
+
+                            if i < currentSelectedAssetIcons.count && !currentSelectedAssetIcons[i].isEmpty {
+                                let selKey = FlutterDartProject.lookupKey(forAsset: currentSelectedAssetIcons[i])
+                                let selRawOriginal = UIImage(named: selKey)
+                                if selRawOriginal != nil {
+                                    selectedImage = self.resizeImage(image: selRawOriginal!)
+                                } else {
+                                    selectedImage = image
+                                }
                             } else {
                                 selectedImage = image
                             }
+                        }
+                    } else if i < currentSymbols.count && !currentSymbols[i].isEmpty {
+                        if #available(iOS 26.0, *) {
+                            let unselTint = bar.unselectedItemTintColor
+
+                            if let unselTint = unselTint {
+                                if let originalImage = UIImage(systemName: currentSymbols[i]) {
+                                    image = originalImage.withTintColor(unselTint, renderingMode: .alwaysOriginal)
+                                }
+                            } else {
+                                image = UIImage(systemName: currentSymbols[i])?.withRenderingMode(.alwaysTemplate)
+                            }
+                            selectedImage = UIImage(systemName: currentSymbols[i])?.withRenderingMode(.alwaysTemplate)
                         } else {
+                            image = UIImage(systemName: currentSymbols[i])
                             selectedImage = image
                         }
                     }
-                } else if i < currentSymbols.count && !currentSymbols[i].isEmpty {
-                    if #available(iOS 26.0, *) {
-                        // Unselected: Only apply custom color if unselectedTint is set
-                        if let unselTint = unselTint {
-                            if let originalImage = UIImage(systemName: currentSymbols[i]) {
-                                image = originalImage.withTintColor(unselTint, renderingMode: .alwaysOriginal)
-                            }
-                        } else {
-                            // No custom color - use template mode to respect theme
-                            image = UIImage(systemName: currentSymbols[i])?.withRenderingMode(.alwaysTemplate)
-                        }
-                        // Selected: Use template rendering so tintColor applies
-                        selectedImage = UIImage(systemName: currentSymbols[i])?.withRenderingMode(.alwaysTemplate)
-                    } else {
-                        image = UIImage(systemName: currentSymbols[i])
-                        selectedImage = image
-                    }
-                }
 
-                item = UITabBarItem(title: title, image: image, selectedImage: selectedImage)
-                item.tag = i
+                    item.image = image
+                    item.selectedImage = selectedImage
+                }
             }
 
-            // Set badge value if provided
             if let count = badgeCount, count > 0 {
                 item.badgeValue = count > 99 ? "99+" : String(count)
             }
@@ -665,6 +706,120 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
         return UIColor(red: r, green: g, blue: b, alpha: a)
     }
 
+    private func runtimeFilePath(for index: Int, selected: Bool) -> String {
+        let paths = selected ? currentSelectedFileIcons : currentFileIcons
+        if index < paths.count, !paths[index].isEmpty {
+            return paths[index]
+        }
+        if selected, index < currentFileIcons.count {
+            return currentFileIcons[index]
+        }
+        return ""
+    }
+
+    private func runtimeNetworkURL(for index: Int, selected: Bool) -> String {
+        let urls = selected ? currentSelectedNetworkIcons : currentNetworkIcons
+        if index < urls.count, !urls[index].isEmpty {
+            return urls[index]
+        }
+        if selected, index < currentNetworkIcons.count {
+            return currentNetworkIcons[index]
+        }
+        return ""
+    }
+
+    private func hasRuntimeImage(for index: Int) -> Bool {
+        return !runtimeFilePath(for: index, selected: false).isEmpty ||
+            !runtimeNetworkURL(for: index, selected: false).isEmpty ||
+            !runtimeFilePath(for: index, selected: true).isEmpty ||
+            !runtimeNetworkURL(for: index, selected: true).isEmpty
+    }
+
+    private func placeholderAvatarImage() -> UIImage? {
+        return UIImage(systemName: "person.crop.circle")
+    }
+
+    private func loadRuntimeImage(filePath: String, networkURL: String) -> UIImage? {
+        if !filePath.isEmpty, let image = UIImage(contentsOfFile: filePath) {
+            return avatarImage(from: image)
+        }
+
+        if !networkURL.isEmpty, let cached = imageCache.object(forKey: networkURL as NSString) {
+            return avatarImage(from: cached)
+        }
+
+        return nil
+    }
+
+    private func fetchNetworkImageIfNeeded(
+        urlString: String,
+        completion: @escaping (UIImage?) -> Void
+    ) {
+        guard !urlString.isEmpty else {
+            completion(nil)
+            return
+        }
+
+        if let cached = imageCache.object(forKey: urlString as NSString) {
+            completion(avatarImage(from: cached))
+            return
+        }
+
+        guard let url = URL(string: urlString) else {
+            completion(nil)
+            return
+        }
+
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+            guard let self = self,
+                  let data = data,
+                  let image = UIImage(data: data) else {
+                DispatchQueue.main.async { completion(nil) }
+                return
+            }
+
+            self.imageCache.setObject(image, forKey: urlString as NSString)
+            let avatar = self.avatarImage(from: image)
+            DispatchQueue.main.async {
+                completion(avatar)
+            }
+        }.resume()
+    }
+
+    private func configureRuntimeImages(for item: UITabBarItem, index: Int) -> Bool {
+        guard hasRuntimeImage(for: index) else { return false }
+
+        let unselectedFile = runtimeFilePath(for: index, selected: false)
+        let selectedFile = runtimeFilePath(for: index, selected: true)
+        let unselectedNetwork = runtimeNetworkURL(for: index, selected: false)
+        let selectedNetwork = runtimeNetworkURL(for: index, selected: true)
+
+        let unselectedImage = loadRuntimeImage(filePath: unselectedFile, networkURL: unselectedNetwork)
+        let selectedImage = loadRuntimeImage(filePath: selectedFile, networkURL: selectedNetwork)
+
+        item.image = (unselectedImage ?? placeholderAvatarImage())?.withRenderingMode(.alwaysOriginal)
+        item.selectedImage = (selectedImage ?? unselectedImage ?? placeholderAvatarImage())?.withRenderingMode(.alwaysOriginal)
+
+        if unselectedImage == nil && !unselectedNetwork.isEmpty {
+            fetchNetworkImageIfNeeded(urlString: unselectedNetwork) { [weak item] avatar in
+                guard let item = item, let avatar = avatar else { return }
+                item.image = avatar.withRenderingMode(.alwaysOriginal)
+                if selectedImage == nil && selectedNetwork.isEmpty && selectedFile.isEmpty {
+                    item.selectedImage = avatar.withRenderingMode(.alwaysOriginal)
+                }
+            }
+        }
+
+        if selectedImage == nil && !selectedNetwork.isEmpty {
+            fetchNetworkImageIfNeeded(urlString: selectedNetwork) { [weak item] avatar in
+                guard let item = item, let avatar = avatar else { return }
+                item.selectedImage = avatar.withRenderingMode(.alwaysOriginal)
+            }
+        }
+
+        return true
+    }
+
     private func resizeImage(image: UIImage, targetSize: CGSize = CGSize(width: 26, height: 26)) -> UIImage {
         let size = image.size
         if size.width <= targetSize.width && size.height <= targetSize.height {
@@ -691,6 +846,22 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
             let newImage = UIGraphicsGetImageFromCurrentImageContext()
             UIGraphicsEndImageContext()
             return newImage ?? image
+        }
+    }
+
+    private func avatarImage(from image: UIImage, targetSize: CGSize = CGSize(width: 26, height: 26)) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        return renderer.image { _ in
+            UIBezierPath(ovalIn: CGRect(origin: .zero, size: targetSize)).addClip()
+
+            let aspectFillScale = max(targetSize.width / image.size.width, targetSize.height / image.size.height)
+            let scaledSize = CGSize(width: image.size.width * aspectFillScale, height: image.size.height * aspectFillScale)
+            let origin = CGPoint(
+                x: (targetSize.width - scaledSize.width) / 2.0,
+                y: (targetSize.height - scaledSize.height) / 2.0
+            )
+
+            image.draw(in: CGRect(origin: origin, size: scaledSize))
         }
     }
 }

--- a/lib/src/widgets/adaptive_scaffold.dart
+++ b/lib/src/widgets/adaptive_scaffold.dart
@@ -20,7 +20,13 @@ class AdaptiveNavigationDestination {
     this.addSpacerAfter = false,
   });
 
-  /// Icon to display (SF Symbol name for iOS, IconData for cross-platform)
+  /// Icon to display.
+  ///
+  /// Supported values include:
+  /// - SF Symbol name `String` for iOS native paths
+  /// - `IconData`
+  /// - `Widget`
+  /// - `ImageProvider` such as `AssetImage`, `FileImage`, or `NetworkImage`
   final dynamic icon;
 
   /// Label text for the destination
@@ -346,32 +352,16 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
               onTap: widget.bottomNavigationBar!.onTap!,
               activeColor: widget.bottomNavigationBar!.selectedItemColor,
               items: widget.bottomNavigationBar!.items!.map((dest) {
-                // Determine icon widget
-                Widget iconWidget;
-                if (dest.icon is Widget) {
-                  iconWidget = unselectedColor != null && dest.icon is ImageIcon
-                      ? ImageIcon((dest.icon as ImageIcon).image, color: unselectedColor)
-                      : (dest.icon as Widget);
-                } else {
-                  final IconData iconData = dest.icon is String
-                      ? _sfSymbolToCupertinoIcon(dest.icon as String)
-                      : dest.icon as IconData;
-                  iconWidget = unselectedColor != null
-                      ? Icon(iconData, color: unselectedColor)
-                      : Icon(iconData);
-                }
+                Widget iconWidget = _buildNavigationIconWidget(
+                  rawIcon: dest.icon,
+                  color: unselectedColor,
+                  platform: TargetPlatform.iOS,
+                );
 
-                // Determine selected icon widget
-                Widget activeIconWidget;
-                final selectedIconRaw = dest.selectedIcon ?? dest.icon;
-                if (selectedIconRaw is Widget) {
-                  activeIconWidget = selectedIconRaw;
-                } else {
-                  final IconData iconData = selectedIconRaw is String
-                      ? _sfSymbolToCupertinoIcon(selectedIconRaw)
-                      : selectedIconRaw as IconData;
-                  activeIconWidget = Icon(iconData);
-                }
+                Widget activeIconWidget = _buildNavigationIconWidget(
+                  rawIcon: dest.selectedIcon ?? dest.icon,
+                  platform: TargetPlatform.iOS,
+                );
 
                 if (dest.badgeCount != null && dest.badgeCount! > 0) {
                   iconWidget = AdaptiveBadge(
@@ -617,22 +607,15 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
           onDestinationSelected: widget.bottomNavigationBar!.onTap!,
           indicatorColor: widget.bottomNavigationBar!.selectedItemColor,
           destinations: widget.bottomNavigationBar!.items!.map((dest) {
-            Widget iconWidget;
-            if (dest.icon is Widget) {
-              iconWidget = dest.icon as Widget;
-            } else {
-              final IconData iconData = dest.icon is String ? Icons.circle : dest.icon as IconData;
-              iconWidget = Icon(iconData);
-            }
+            Widget iconWidget = _buildNavigationIconWidget(
+              rawIcon: dest.icon,
+              platform: TargetPlatform.android,
+            );
 
-            Widget selectedIconWidget;
-            final selectedIconRaw = dest.selectedIcon ?? dest.icon;
-            if (selectedIconRaw is Widget) {
-              selectedIconWidget = selectedIconRaw;
-            } else {
-              final IconData iconData = selectedIconRaw is String ? Icons.circle : selectedIconRaw as IconData;
-              selectedIconWidget = Icon(iconData);
-            }
+            Widget selectedIconWidget = _buildNavigationIconWidget(
+              rawIcon: dest.selectedIcon ?? dest.icon,
+              platform: TargetPlatform.android,
+            );
 
             if (dest.badgeCount != null && dest.badgeCount! > 0) {
               iconWidget = AdaptiveBadge(
@@ -747,6 +730,55 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
       'checkmark.circle': CupertinoIcons.checkmark_circle,
     };
     return iconMap[sfSymbol] ?? CupertinoIcons.circle;
+  }
+
+  Widget _buildNavigationIconWidget({
+    required dynamic rawIcon,
+    Color? color,
+    required TargetPlatform platform,
+  }) {
+    if (rawIcon is Widget) {
+      return color != null && rawIcon is ImageIcon
+          ? ImageIcon(rawIcon.image, color: color)
+          : rawIcon;
+    }
+
+    if (rawIcon is ImageProvider) {
+      return _NavigationImageIcon(image: rawIcon);
+    }
+
+    final IconData iconData;
+    if (rawIcon is String) {
+      iconData = platform == TargetPlatform.iOS
+          ? _sfSymbolToCupertinoIcon(rawIcon)
+          : Icons.circle;
+    } else {
+      iconData = rawIcon as IconData;
+    }
+
+    return color != null ? Icon(iconData, color: color) : Icon(iconData);
+  }
+}
+
+class _NavigationImageIcon extends StatelessWidget {
+  const _NavigationImageIcon({required this.image});
+
+  final ImageProvider image;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 26,
+      height: 26,
+      child: ClipOval(
+        child: Image(
+          image: image,
+          fit: BoxFit.cover,
+          errorBuilder: (_, __, ___) =>
+              const Icon(CupertinoIcons.person_crop_circle),
+        ),
+      ),
+    );
   }
 }
 

--- a/lib/src/widgets/ios26/ios26_native_tab_bar.dart
+++ b/lib/src/widgets/ios26/ios26_native_tab_bar.dart
@@ -56,6 +56,10 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
   List<String>? _lastSymbols;
   List<String>? _lastAssetIcons;
   List<String>? _lastSelectedAssetIcons;
+  List<String>? _lastFileIcons;
+  List<String>? _lastSelectedFileIcons;
+  List<String>? _lastNetworkIcons;
+  List<String>? _lastSelectedNetworkIcons;
   List<int?>? _lastBadgeCounts;
   TabBarMinimizeBehavior? _lastMinimizeBehavior;
   bool? _lastHidden;
@@ -122,6 +126,22 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
     return '';
   }
 
+  String _extractFilePath(Object? icon) {
+    if (icon is FileImage) return icon.file.path;
+    if (icon is ImageIcon && icon.image is FileImage) {
+      return (icon.image as FileImage).file.path;
+    }
+    return '';
+  }
+
+  String _extractNetworkUrl(Object? icon) {
+    if (icon is NetworkImage) return icon.url;
+    if (icon is ImageIcon && icon.image is NetworkImage) {
+      return (icon.image as NetworkImage).url;
+    }
+    return '';
+  }
+
   List<String> _mapSymbols() =>
       widget.destinations.map((e) => _extractSymbol(e.icon)).toList();
 
@@ -132,6 +152,20 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
       .map((e) => _extractAssetPath(e.selectedIcon ?? e.icon))
       .toList();
 
+  List<String> _mapFileIcons() =>
+      widget.destinations.map((e) => _extractFilePath(e.icon)).toList();
+
+  List<String> _mapSelectedFileIcons() => widget.destinations
+      .map((e) => _extractFilePath(e.selectedIcon ?? e.icon))
+      .toList();
+
+  List<String> _mapNetworkIcons() =>
+      widget.destinations.map((e) => _extractNetworkUrl(e.icon)).toList();
+
+  List<String> _mapSelectedNetworkIcons() => widget.destinations
+      .map((e) => _extractNetworkUrl(e.selectedIcon ?? e.icon))
+      .toList();
+
   @override
   Widget build(BuildContext context) {
     if (!kIsWeb && Platform.isIOS) {
@@ -139,6 +173,10 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
       final symbols = _mapSymbols();
       final assetIcons = _mapAssetIcons();
       final selectedAssetIcons = _mapSelectedAssetIcons();
+      final fileIcons = _mapFileIcons();
+      final selectedFileIcons = _mapSelectedFileIcons();
+      final networkIcons = _mapNetworkIcons();
+      final selectedNetworkIcons = _mapSelectedNetworkIcons();
 
       final searchFlags = widget.destinations.map((e) => e.isSearch).toList();
       final badgeCounts = widget.destinations.map((e) => e.badgeCount).toList();
@@ -151,6 +189,10 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
         'sfSymbols': symbols,
         'assetIcons': assetIcons,
         'selectedAssetIcons': selectedAssetIcons,
+        'fileIcons': fileIcons,
+        'selectedFileIcons': selectedFileIcons,
+        'networkIcons': networkIcons,
+        'selectedNetworkIcons': selectedNetworkIcons,
         'searchFlags': searchFlags,
         'badgeCounts': badgeCounts,
         'spacerFlags': spacerFlags,
@@ -226,7 +268,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
     final ch = MethodChannel('adaptive_platform_ui/ios26_tab_bar_$id');
     _channel = ch;
     ch.setMethodCallHandler(_onMethodCall);
-    _lastIndex = widget.selectedIndex;
+    _lastIndex = null;
     _lastTint = _effectiveTint != null ? _colorToARGB(_effectiveTint!) : null;
     _lastUnselectedTint = widget.unselectedItemTint != null
         ? _colorToARGB(widget.unselectedItemTint!)
@@ -239,6 +281,10 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
     _lastMinimizeBehavior = widget.minimizeBehavior;
     _requestIntrinsicSize();
     _cacheItems();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted || _channel != ch) return;
+      _pushInitialStateToNative(ch);
+    });
   }
 
   Future<dynamic> _onMethodCall(MethodCall call) async {
@@ -293,18 +339,31 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
     final symbols = _mapSymbols();
     final assetIcons = _mapAssetIcons();
     final selectedAssetIcons = _mapSelectedAssetIcons();
+    final fileIcons = _mapFileIcons();
+    final selectedFileIcons = _mapSelectedFileIcons();
+    final networkIcons = _mapNetworkIcons();
+    final selectedNetworkIcons = _mapSelectedNetworkIcons();
     final searchFlags = widget.destinations.map((e) => e.isSearch).toList();
     final badgeCounts = widget.destinations.map((e) => e.badgeCount).toList();
 
     if (_lastLabels?.join('|') != labels.join('|') ||
         _lastSymbols?.join('|') != symbols.join('|') ||
         _lastAssetIcons?.join('|') != assetIcons.join('|') ||
-        _lastSelectedAssetIcons?.join('|') != selectedAssetIcons.join('|')) {
+        _lastSelectedAssetIcons?.join('|') != selectedAssetIcons.join('|') ||
+        _lastFileIcons?.join('|') != fileIcons.join('|') ||
+        _lastSelectedFileIcons?.join('|') != selectedFileIcons.join('|') ||
+        _lastNetworkIcons?.join('|') != networkIcons.join('|') ||
+        _lastSelectedNetworkIcons?.join('|') !=
+            selectedNetworkIcons.join('|')) {
       await ch.invokeMethod('setItems', {
         'labels': labels,
         'sfSymbols': symbols,
         'assetIcons': assetIcons,
         'selectedAssetIcons': selectedAssetIcons,
+        'fileIcons': fileIcons,
+        'selectedFileIcons': selectedFileIcons,
+        'networkIcons': networkIcons,
+        'selectedNetworkIcons': selectedNetworkIcons,
         'searchFlags': searchFlags,
         'badgeCounts': badgeCounts,
         'selectedIndex': widget.selectedIndex,
@@ -313,6 +372,10 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
       _lastSymbols = symbols;
       _lastAssetIcons = assetIcons;
       _lastSelectedAssetIcons = selectedAssetIcons;
+      _lastFileIcons = fileIcons;
+      _lastSelectedFileIcons = selectedFileIcons;
+      _lastNetworkIcons = networkIcons;
+      _lastSelectedNetworkIcons = selectedNetworkIcons;
       _requestIntrinsicSize();
     }
 
@@ -364,6 +427,10 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
     _lastSymbols = _mapSymbols();
     _lastAssetIcons = _mapAssetIcons();
     _lastSelectedAssetIcons = _mapSelectedAssetIcons();
+    _lastFileIcons = _mapFileIcons();
+    _lastSelectedFileIcons = _mapSelectedFileIcons();
+    _lastNetworkIcons = _mapNetworkIcons();
+    _lastSelectedNetworkIcons = _mapSelectedNetworkIcons();
     _lastBadgeCounts = widget.destinations.map((e) => e.badgeCount).toList();
   }
 
@@ -387,6 +454,53 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
       setState(() {
         if (h != null && h > 0) _intrinsicHeight = h;
       });
+    } catch (_) {}
+  }
+
+  Future<void> _pushInitialStateToNative(MethodChannel ch) async {
+    final labels = widget.destinations.map((e) => e.label).toList();
+    final symbols = _mapSymbols();
+    final assetIcons = _mapAssetIcons();
+    final selectedAssetIcons = _mapSelectedAssetIcons();
+    final fileIcons = _mapFileIcons();
+    final selectedFileIcons = _mapSelectedFileIcons();
+    final networkIcons = _mapNetworkIcons();
+    final selectedNetworkIcons = _mapSelectedNetworkIcons();
+    final searchFlags = widget.destinations.map((e) => e.isSearch).toList();
+    final badgeCounts = widget.destinations.map((e) => e.badgeCount).toList();
+
+    try {
+      await ch.invokeMethod('setItems', {
+        'labels': labels,
+        'sfSymbols': symbols,
+        'assetIcons': assetIcons,
+        'selectedAssetIcons': selectedAssetIcons,
+        'fileIcons': fileIcons,
+        'selectedFileIcons': selectedFileIcons,
+        'networkIcons': networkIcons,
+        'selectedNetworkIcons': selectedNetworkIcons,
+        'searchFlags': searchFlags,
+        'badgeCounts': badgeCounts,
+        'selectedIndex': widget.selectedIndex,
+      });
+
+      final style = <String, dynamic>{};
+      if (_effectiveTint != null) {
+        style['tint'] = _colorToARGB(_effectiveTint!);
+      }
+      if (widget.unselectedItemTint != null) {
+        style['unselectedItemTint'] = _colorToARGB(widget.unselectedItemTint!);
+      }
+      if (widget.backgroundColor != null) {
+        style['backgroundColor'] = _colorToARGB(widget.backgroundColor!);
+      }
+      if (style.isNotEmpty) {
+        await ch.invokeMethod('setStyle', style);
+      }
+
+      await ch.invokeMethod('setSelectedIndex', {'index': widget.selectedIndex});
+      _lastIndex = widget.selectedIndex;
+      await _requestIntrinsicSize();
     } catch (_) {}
   }
 }


### PR DESCRIPTION
## Description
Adds support for dynamic image-based navigation icons in `AdaptiveBottomNavigationBar`, including the iOS 26+ native tab bar.

This allows apps to use `ImageProvider` values such as `AssetImage`, `FileImage`, and `NetworkImage` for navigation destinations without introducing iOS-specific API fields. The change keeps the API cross-platform while enabling dynamic avatars and other runtime images in the native iOS 26 tab bar.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
Closes #

## Changes Made
- Added `ImageProvider` support to `AdaptiveNavigationDestination.icon` and `selectedIcon`, including `AssetImage`, `FileImage`, and `NetworkImage`.
- Updated the iOS 26+ native tab bar bridge to pass file- and network-backed image sources from Flutter to native code.
- Added native iOS support for rendering runtime images as circular tab bar icons, with async network loading and caching.
- Updated non-native navigation bars to render `ImageProvider` icons on iOS <26 and Android using the same cross-platform API.
- Documented the expanded supported icon types in `AdaptiveNavigationDestination`.

## Testing

### Automated Tests ⚠️ **REQUIRED**
- [ ] I have added unit/widget tests for my changes
- [ ] All new and existing tests pass locally (`flutter test`)
- [x] Code analysis passes with no errors (`flutter analyze`)
- [ ] Code formatting is correct (`dart format`)
- [ ] Test coverage is adequate (>80% for new code)

### Manual Testing
- [x] iOS 26+ tested
- [x] iOS <26 tested
- [x] Android tested
- [ ] Web tested (if applicable)
- [x] Tested in both light and dark mode
- [ ] Tested with different screen sizes
- [ ] Tested with accessibility features (large fonts, screen readers, etc.)

## Screenshots/Videos

### Before
The iOS 26+ native tab bar only supported SF Symbols and bundled asset icons. Apps could not use runtime images such as a user profile photo in a native tab bar item without adding platform-specific API.

### After
Apps can pass `ImageProvider` values to navigation destinations and have them render across platforms, including dynamic images in the iOS 26+ native tab bar.
<img width="768" height="140" alt="image" src="https://github.com/user-attachments/assets/6a4d60a6-abbc-40dc-a730-28069e7a3f3d" />

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that my code does not introduce any accessibility issues
- [ ] I have updated the CHANGELOG.md file (if applicable)
- [ ] I have updated version number in pubspec.yaml (if applicable)
- [ ] I have added examples to the example app (if adding new widgets)

## Breaking Changes
None.

## Additional Notes
This change is intentionally API-neutral for platform consumers. Instead of introducing iOS-specific destination fields, it extends the existing `icon` / `selectedIcon` contract so the same image source can be used across iOS 26+, iOS <26, and Android.

## Demo Code
```dart
AdaptiveNavigationDestination(
  icon: NetworkImage(userAvatarUrl),
  selectedIcon: NetworkImage(userAvatarUrl),
  label: 'Profile',
)
