### PR TITLE
fix: remove delay of dimmed background removal when closing alert (#87)

### DIFF
--- a/lib/src/widgets/adaptive_alert_dialog.dart
+++ b/lib/src/widgets/adaptive_alert_dialog.dart
@@ -71,6 +71,7 @@ class AdaptiveAlertDialog {
 
       return showCupertinoDialog<void>(
         context: context,
+        barrierColor: CupertinoColors.transparent,
         builder: (context) => IOS26AlertDialog(
           title: title,
           message: message,

--- a/lib/src/widgets/ios26/ios26_alert_dialog.dart
+++ b/lib/src/widgets/ios26/ios26_alert_dialog.dart
@@ -179,14 +179,11 @@ class _IOS26AlertDialogState extends State<IOS26AlertDialog> {
       );
 
       // Alert dialogs are modal and should fill the screen
-      return Container(
-        color: const Color(0x42000000), // Semi-transparent overlay
-        child: Center(
-          child: SizedBox(
-            width: 270, // Standard iOS alert width
-            height: 200, // Approximate height, will be adjusted by native
-            child: platformView,
-          ),
+      return Center(
+        child: SizedBox(
+          width: 270, // Standard iOS alert width
+          height: 200, // Approximate height, will be adjusted by native
+          child: platformView,
         ),
       );
     }


### PR DESCRIPTION
## Description
As pointed out in issue #87 there's a delay when closing an alert until the background "undims". 
The dim is currently coming from 3 separate locations. The showCupertinoDialog adds a dim to the background, the Container adds a dim and in the UiAlertController also adds dim. 

I think it would make sense to have the dim only controlled by one place, so either in Flutter or swift. To make it as native as possible I'd suggest removing the dim in the flutter code. However, I don't fully understand the intention behind making the dim darker with the Container so you might have another approach to this.


## Type of Change
<!-- Please check the relevant option(s) -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
Closes #87 

## Changes Made
- Removed Container wrapping alert
- Adding transparent color to the [cupertinoDialog](https://api.flutter.dev/flutter/cupertino/showCupertinoDialog.html) background


## Testing
Included videos showcasing the difference

### Automated Tests ⚠️ **REQUIRED**
<!-- All PRs that add or modify functionality MUST include tests -->
- [ ] I have added unit/widget tests for my changes
- [ ] All new and existing tests pass locally (`flutter test`)
- [ ] Code analysis passes with no errors (`flutter analyze`)
- [ ] Code formatting is correct (`dart format`)
- [ ] Test coverage is adequate (>80% for new code)

### Manual Testing
<!-- Check all platforms where you've manually tested these changes -->
- [x ] iOS 26+ tested
- [ ] iOS <26 tested
- [ ] Android tested
- [ ] Web tested (if applicable)
- [ ] Tested in both light and dark mode
- [ ] Tested with different screen sizes
- [ ] Tested with accessibility features (large fonts, screen readers, etc.)


### Before

https://github.com/user-attachments/assets/f221021b-992d-404b-88ff-78dd19dd2918


### After

https://github.com/user-attachments/assets/5488371b-744e-4a3d-a419-112399a8fce0


## Checklist
<!-- Please check all that apply -->
- [ x ] My code follows the style guidelines of this project
- [x  ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [ ] I have checked that my code does not introduce any accessibility issues
- [ ] I have updated the CHANGELOG.md file (if applicable)
- [ ] I have updated version number in pubspec.yaml (if applicable)
- [ ] I have added examples to the example app (if adding new widgets)

## Breaking Changes
None


