### PR TITLE
fix navigation bar rendering on iOS26

### DIFF
--- a/ios/Classes/iOS26TabBarPlatformView.swift
+++ b/ios/Classes/iOS26TabBarPlatformView.swift
@@ -1,9 +1,27 @@
 import Flutter
 import UIKit
 
+private final class LayoutAwareTabBarContainerView: UIView {
+    var onWidthChanged: ((CGFloat) -> Void)?
+    private var lastReportedWidth: CGFloat = 0
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard window != nil else { return }
+
+        let width = bounds.width
+        guard width > 0 else { return }
+        guard abs(width - lastReportedWidth) > 0.5 else { return }
+
+        lastReportedWidth = width
+        onWidthChanged?(width)
+    }
+}
+
 class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
     private let channel: FlutterMethodChannel
-    private let container: UIView
+    private let container: LayoutAwareTabBarContainerView
     private var tabBar: UITabBar?
     private var minimizeBehavior: Int = 3 // automatic
     private var currentLabels: [String] = []
@@ -23,7 +41,7 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
             name: "adaptive_platform_ui/ios26_tab_bar_\(viewId)",
             binaryMessenger: messenger
         )
-        self.container = UIView(frame: frame)
+        self.container = LayoutAwareTabBarContainerView(frame: frame)
 
         var labels: [String] = []
         var symbols: [String] = []
@@ -288,6 +306,10 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
         // Apply minimize behavior if available
         self.applyMinimizeBehavior()
 
+        container.onWidthChanged = { [weak self] _ in
+            self?.handleContainerWidthChange()
+        }
+
         // Setup method call handler
         channel.setMethodCallHandler { [weak self] call, result in
             guard let self = self else { result(nil); return }
@@ -305,6 +327,21 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
         //
         // This method stores the behavior preference for future use
         // The actual minimization animation should be handled by Flutter
+    }
+
+    private func handleContainerWidthChange() {
+        guard let bar = self.tabBar else { return }
+
+        // A standalone UITabBar hosted in a platform view can lay out once
+        // before it has its final width. Rebuild against the real container
+        // width so item labels and spacing are computed from the final bounds.
+        if #available(iOS 26.0, *) {
+            rebuildItemsWithCurrentState()
+        }
+
+        bar.setNeedsLayout()
+        bar.layoutIfNeeded()
+        container.setNeedsLayout()
     }
 
     private func handleMethodCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -493,9 +530,10 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                     self.tabBar?.unselectedItemTintColor = c
                     NSLog("✅ setStyle: unselectedItemTintColor set to \(c)")
 
-                    // iOS 26+: Rebuild items with new unselected color
+                    // iOS 26+: Rebuild items with current state so untinted
+                    // and tinted icon variants are regenerated consistently.
                     if #available(iOS 26.0, *) {
-                        self.rebuildItemsWithCurrentColors()
+                        self.rebuildItemsWithCurrentState()
                     }
                 }
                 unselectedColor = c
@@ -582,8 +620,8 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
         }
     }
 
-    // iOS 26+: Rebuild tab items with current colors
-    private func rebuildItemsWithCurrentColors() {
+    // iOS 26+: Rebuild tab items from the current native state.
+    private func rebuildItemsWithCurrentState() {
         guard let bar = self.tabBar else { return }
 
         let currentSelectedIndex = bar.items?.firstIndex { $0 == bar.selectedItem } ?? 0


### PR DESCRIPTION
## Description
Fixes an iOS 26+ native tab bar initialization issue where tab labels and item layout could appear truncated or ellipsized on cold launch, then correct themselves after the user interacts with the tab bar.

The fix removes the timing-based retry approach and instead refreshes the standalone native `UITabBar` when its hosting platform view receives its real layout width. This makes the initial layout deterministic and aligned with the actual native view lifecycle.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
Closes #

## Changes Made
- Added a native layout-aware container view for the iOS 26+ tab bar platform view to detect when the hosted `UITabBar` receives its real width.
- Rebuilt and relaid out the standalone native `UITabBar` from current state when the platform view width becomes available, so labels and spacing are computed from final bounds instead of an early provisional layout.
- Removed the Dart-side delayed retry from the iOS 26 native tab bar wrapper and kept the fix anchored to the native layout lifecycle instead of elapsed time.

## Testing

### Automated Tests ⚠️ **REQUIRED**
- [ ] I have added unit/widget tests for my changes
- [ ] All new and existing tests pass locally (`flutter test`)
- [x] Code analysis passes with no errors (`flutter analyze`)
- [ ] Code formatting is correct (`dart format`)
- [ ] Test coverage is adequate (>80% for new code)

### Manual Testing
- [x] iOS 26+ tested
- [ ] iOS <26 tested
- [ ] Android tested
- [ ] Web tested (if applicable)
- [x] Tested in both light and dark mode
- [ ] Tested with different screen sizes
- [ ] Tested with accessibility features (large fonts, screen readers, etc.)

## Screenshots/Videos

### Before
On iOS 26+, when using the native tab bar path, cold launching the app could render tab labels with ellipses and incorrect spacing. Tapping another tab or otherwise causing a later native layout/update would make the labels render correctly.

<img width="1210" height="215" alt="image" src="https://github.com/user-attachments/assets/7745052f-dc48-40a9-a47e-99967123124b" />

### After
On iOS 26+, the native tab bar refreshes when its hosting platform view reaches its actual layout width, so tab labels and spacing render correctly on cold launch without relying on delayed retries or user interaction.

<img width="1320" height="291" alt="IMG_2792" src="https://github.com/user-attachments/assets/486ca5b5-5252-42c1-ab35-6637879deefc" />

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that my code does not introduce any accessibility issues
- [ ] I have updated the CHANGELOG.md file (if applicable)
- [ ] I have updated version number in pubspec.yaml (if applicable)
- [ ] I have added examples to the example app (if adding new widgets)

## Breaking Changes
None.

## Additional Notes
This fix is intentionally native-layout-driven rather than time-driven. The issue occurs because the iOS 26 implementation hosts a standalone `UITabBar` inside a Flutter platform view rather than a full `UITabBarController`, so the correct recovery point is when the native host view receives its final bounds.

## Demo Code
```dart
AdaptiveBottomNavigationBar(
  useNativeBottomBar: true,
  selectedIndex: selectedIndex,
  onTap: onTap,
  items: const [
    AdaptiveNavigationDestination(
      icon: 'timer',
      selectedIcon: 'timer',
      label: 'Countdowns',
    ),
    AdaptiveNavigationDestination(
      icon: 'heart',
      selectedIcon: 'heart.fill',
      label: 'Favorites',
    ),
    AdaptiveNavigationDestination(
      icon: 'plus.circle',
      selectedIcon: 'plus.circle.fill',
      label: 'Create New',
    ),
  ],
)
