### PR TITLE
add resize to avoid inset option

### DIFF
--- a/lib/src/widgets/adaptive_scaffold.dart
+++ b/lib/src/widgets/adaptive_scaffold.dart
@@ -246,24 +246,24 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
         }).toList();
       }
 
-        return _wrapWithDrawerIfNeeded(
-          IOS26Scaffold(
-            key: ValueKey(
-              'ios26_scaffold_${widget.bottomNavigationBar?.selectedIndex ?? 0}_${widget.body?.runtimeType.toString() ?? "empty"}',
-            ),
+      return _wrapWithDrawerIfNeeded(
+        IOS26Scaffold(
+          key: ValueKey(
+            'ios26_scaffold_${widget.bottomNavigationBar?.selectedIndex ?? 0}_${widget.body?.runtimeType.toString() ?? "empty"}',
+          ),
           bottomNavigationBar: widget.bottomNavigationBar,
           title: widget.appBar?.title,
           actions: widget.appBar?.actions,
           leading: widget.appBar?.leading,
           tintColor: widget.appBar?.tintColor,
-            minimizeBehavior: widget.minimizeBehavior,
-            enableBlur: widget.enableBlur,
-            useHeroBackButton: widget.useHeroBackButton,
-            tabBarHidden: widget.tabBarHidden,
-            resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset,
-            children: childrenList,
-          ),
-        );
+          minimizeBehavior: widget.minimizeBehavior,
+          enableBlur: widget.enableBlur,
+          useHeroBackButton: widget.useHeroBackButton,
+          tabBarHidden: widget.tabBarHidden,
+          resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset,
+          children: childrenList,
+        ),
+      );
     }
 
     // iOS <26 (iOS 18 and below) OR iOS 26+ with useNativeToolbar: false

--- a/lib/src/widgets/adaptive_scaffold.dart
+++ b/lib/src/widgets/adaptive_scaffold.dart
@@ -72,6 +72,7 @@ class AdaptiveScaffold extends StatefulWidget {
     this.appBar,
     this.bottomNavigationBar,
     this.body,
+    this.resizeToAvoidBottomInset,
     this.floatingActionButton,
     this.minimizeBehavior = TabBarMinimizeBehavior.automatic,
     this.enableBlur = true,
@@ -99,6 +100,13 @@ class AdaptiveScaffold extends StatefulWidget {
 
   /// Body widget
   final Widget? body;
+
+  /// Whether the scaffold should resize when the on-screen keyboard appears.
+  ///
+  /// When null, each platform path uses its existing default behavior.
+  /// Set to `false` to keep bottom navigation pinned while the keyboard
+  /// overlays content, such as on iOS tab-based layouts.
+  final bool? resizeToAvoidBottomInset;
 
   /// Floating action button (Material only)
   final Widget? floatingActionButton;
@@ -238,23 +246,24 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
         }).toList();
       }
 
-      return _wrapWithDrawerIfNeeded(
-        IOS26Scaffold(
-          key: ValueKey(
-            'ios26_scaffold_${widget.bottomNavigationBar?.selectedIndex ?? 0}_${widget.body?.runtimeType.toString() ?? "empty"}',
-          ),
+        return _wrapWithDrawerIfNeeded(
+          IOS26Scaffold(
+            key: ValueKey(
+              'ios26_scaffold_${widget.bottomNavigationBar?.selectedIndex ?? 0}_${widget.body?.runtimeType.toString() ?? "empty"}',
+            ),
           bottomNavigationBar: widget.bottomNavigationBar,
           title: widget.appBar?.title,
           actions: widget.appBar?.actions,
           leading: widget.appBar?.leading,
           tintColor: widget.appBar?.tintColor,
-          minimizeBehavior: widget.minimizeBehavior,
-          enableBlur: widget.enableBlur,
-          useHeroBackButton: widget.useHeroBackButton,
-          tabBarHidden: widget.tabBarHidden,
-          children: childrenList,
-        ),
-      );
+            minimizeBehavior: widget.minimizeBehavior,
+            enableBlur: widget.enableBlur,
+            useHeroBackButton: widget.useHeroBackButton,
+            tabBarHidden: widget.tabBarHidden,
+            resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset,
+            children: childrenList,
+          ),
+        );
     }
 
     // iOS <26 (iOS 18 and below) OR iOS 26+ with useNativeToolbar: false
@@ -457,7 +466,8 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
 
         return _wrapWithDrawerIfNeeded(
           CupertinoPageScaffold(
-            resizeToAvoidBottomInset: !hasNativeTabBar,
+            resizeToAvoidBottomInset:
+                widget.resizeToAvoidBottomInset ?? !hasNativeTabBar,
             navigationBar: navigationBar,
             child: bodyWidget,
           ),
@@ -641,6 +651,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
         key: widget.scaffoldKey,
         appBar: appBar,
         body: widget.body ?? const SizedBox.shrink(),
+        resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset,
         bottomNavigationBar: bottomNavBar,
         floatingActionButton: widget.floatingActionButton,
         extendBodyBehindAppBar: widget.extendBodyBehindAppBar,
@@ -693,6 +704,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
       key: widget.scaffoldKey,
       appBar: appBar,
       body: widget.body ?? const SizedBox.shrink(),
+      resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset,
       floatingActionButton: widget.floatingActionButton,
       extendBodyBehindAppBar: widget.extendBodyBehindAppBar,
       drawer: widget.drawer,

--- a/lib/src/widgets/ios26/ios26_scaffold.dart
+++ b/lib/src/widgets/ios26/ios26_scaffold.dart
@@ -20,6 +20,7 @@ class IOS26Scaffold extends StatefulWidget {
     this.enableBlur = true,
     this.useHeroBackButton = true,
     this.tabBarHidden = false,
+    this.resizeToAvoidBottomInset,
     required this.children,
   });
 
@@ -32,6 +33,7 @@ class IOS26Scaffold extends StatefulWidget {
   final bool enableBlur;
   final bool useHeroBackButton;
   final bool tabBarHidden;
+  final bool? resizeToAvoidBottomInset;
   final List<Widget> children;
 
   @override
@@ -287,7 +289,7 @@ class _IOS26ScaffoldState extends State<IOS26Scaffold>
       // inside a Stack. If the scaffold resizes for the keyboard the tab bar
       // floats above it — non-standard on iOS. Disable the resize so the
       // keyboard window (higher z-order) covers the tab bar naturally.
-      resizeToAvoidBottomInset: !hasBottomNav,
+      resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset ?? !hasBottomNav,
       child: hasBottomNav
           ? NotificationListener<ScrollNotification>(
               onNotification: _handleScrollNotification,

--- a/lib/src/widgets/ios26/ios26_scaffold.dart
+++ b/lib/src/widgets/ios26/ios26_scaffold.dart
@@ -111,7 +111,7 @@ class _IOS26ScaffoldState extends State<IOS26Scaffold>
   /// Determines if the current window is in a windowed mode.
   ///
   /// This method compares the display size of the device with the viewport size
-  /// calculated from the logical size and device pixel ratio. 
+  /// calculated from the logical size and device pixel ratio.
   /// It returns true if the sizes do not match, indicating that the application is not in full-screen mode.
   bool _getIsWindowed() {
     final displaySize = View.of(context).display.size;
@@ -289,7 +289,8 @@ class _IOS26ScaffoldState extends State<IOS26Scaffold>
       // inside a Stack. If the scaffold resizes for the keyboard the tab bar
       // floats above it — non-standard on iOS. Disable the resize so the
       // keyboard window (higher z-order) covers the tab bar naturally.
-      resizeToAvoidBottomInset: widget.resizeToAvoidBottomInset ?? !hasBottomNav,
+      resizeToAvoidBottomInset:
+          widget.resizeToAvoidBottomInset ?? !hasBottomNav,
       child: hasBottomNav
           ? NotificationListener<ScrollNotification>(
               onNotification: _handleScrollNotification,


### PR DESCRIPTION
## Description
Adds a nullable `resizeToAvoidBottomInset` property to `AdaptiveScaffold` and wires it through the iOS 26 scaffold path.

This gives app code explicit control over keyboard-driven scaffold resizing without changing existing default behavior for current package consumers.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
Closes #

## Changes Made
- Added `bool? resizeToAvoidBottomInset` to `AdaptiveScaffold`.
- Passed the new property through the Cupertino, Material, and iOS 26 native scaffold implementations.
- Preserved existing platform-specific behavior when the property is not provided by keeping the default logic behind a nullable API.

## Testing

### Automated Tests ⚠️ **REQUIRED**
- [ ] I have added unit/widget tests for my changes
- [ ] All new and existing tests pass locally (`flutter test`)
- [x] Code analysis passes with no errors (`flutter analyze`)
- [ ] Code formatting is correct (`dart format`)
- [ ] Test coverage is adequate (>80% for new code)

### Manual Testing
- [x] iOS 26+ tested
- [x] iOS <26 tested
- [x] Android tested
- [ ] Web tested (if applicable)
- [x] Tested in both light and dark mode
- [ ] Tested with different screen sizes
- [ ] Tested with accessibility features (large fonts, screen readers, etc.)

## Screenshots/Videos

### Before
`AdaptiveScaffold` did not expose control over `resizeToAvoidBottomInset`, so apps using the package could not opt out of keyboard-driven scaffold resizing on specific platforms or shell layouts. On iOS tab-based layouts, this could cause the bottom navigation bar to move with the keyboard when the app wanted it to stay pinned.

### After
Apps can now explicitly set `resizeToAvoidBottomInset` on `AdaptiveScaffold` to control keyboard resizing behavior, while existing consumers that do not pass the property keep the current default behavior.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked that my code does not introduce any accessibility issues
- [ ] I have updated the CHANGELOG.md file (if applicable)
- [ ] I have updated version number in pubspec.yaml (if applicable)
- [ ] I have added examples to the example app (if adding new widgets)

## Breaking Changes
None.

## Additional Notes
This change is intentionally additive and uses a nullable property to avoid changing existing scaffold behavior for consumers that do not opt in.

## Demo Code
```dart
AdaptiveScaffold(
  resizeToAvoidBottomInset: false,
  appBar: AdaptiveAppBar(
    title: const Text('Create Countdown'),
  ),
  bottomNavigationBar: AdaptiveBottomNavigationBar(
    selectedIndex: selectedIndex,
    onTap: onTap,
    items: items,
  ),
  body: child,
)
