### PR TITLE
fix: remove clamp from IOSSpringCurve and export it publicly

### DIFF
--- a/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26PopupMenuButtonView.swift
+++ b/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26PopupMenuButtonView.swift
@@ -29,6 +29,7 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
         var dividers: [NSNumber] = []
         var enabled: [NSNumber] = []
         var isCustomWidget: Bool = false
+        var triggerOnLongPress: Bool = false
 
         if let dict = args as? [String: Any] {
             if let t = dict["buttonTitle"] as? String { title = t }
@@ -38,6 +39,7 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
             if let tintArgb = dict["tint"] as? NSNumber { tint = UIColor(argb: tintArgb.intValue) }
             if let bs = dict["buttonStyle"] as? String { buttonStyle = bs }
             if let cw = dict["customWidget"] as? NSNumber { isCustomWidget = cw.boolValue }
+            if let lp = dict["triggerOnLongPress"] as? NSNumber { triggerOnLongPress = lp.boolValue }
             labels = (dict["labels"] as? [String]) ?? []
             symbols = (dict["sfSymbols"] as? [String]) ?? []
             dividers = (dict["isDivider"] as? [NSNumber]) ?? []
@@ -94,7 +96,7 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
         rebuildMenu()
 
         if #available(iOS 14.0, *) {
-            button.showsMenuAsPrimaryAction = true
+            button.showsMenuAsPrimaryAction = !triggerOnLongPress
         } else {
             button.addTarget(self, action: #selector(onButtonPressedLegacy(_:)), for: .touchUpInside)
         }

--- a/lib/adaptive_platform_ui.dart
+++ b/lib/adaptive_platform_ui.dart
@@ -30,6 +30,9 @@ library;
 // Platform utilities
 export 'src/platform/platform_info.dart';
 
+// Animation utilities
+export 'src/utils/animation.dart';
+
 // Styles
 export 'src/style/sf_symbol.dart';
 

--- a/lib/src/utils/animation.dart
+++ b/lib/src/utils/animation.dart
@@ -20,6 +20,6 @@ class IOSSpringCurve extends Curve {
     // Simulate over a fixed duration window (e.g. 1.5s)
     // t is [0,1], so we map it into the spring's time domain
     final sim = SpringSimulation(spring, 0, 1, 0);
-    return sim.x(t * 1.5).clamp(0.0, 1.0);
+    return sim.x(t * 1.5);
   }
 }

--- a/lib/src/widgets/adaptive_popup_menu_button.dart
+++ b/lib/src/widgets/adaptive_popup_menu_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import '../platform/platform_info.dart';
 import 'ios26/ios26_popup_menu_button.dart';
@@ -72,6 +73,7 @@ class AdaptivePopupMenuButton<T> {
     Color? tint,
     PopupButtonStyle buttonStyle = PopupButtonStyle.plain,
     bool triggerOnLongPress = false,
+    VoidCallback? onTap,
     required Widget child,
   }) {
     // iOS 26+ - Use gesture detector with native menu
@@ -82,6 +84,7 @@ class AdaptivePopupMenuButton<T> {
         tint: tint,
         buttonStyle: buttonStyle,
         triggerOnLongPress: triggerOnLongPress,
+        onTap: onTap,
         child: child,
       );
     }
@@ -99,7 +102,7 @@ class AdaptivePopupMenuButton<T> {
     // iOS <26 (iOS 18 and below) - Use GestureDetector with action sheet
     return Builder(
       builder: (context) => GestureDetector(
-        onTap: triggerOnLongPress ? null : () => _showMenu<T>(context, null, items, onSelected),
+        onTap: triggerOnLongPress ? onTap : () => _showMenu<T>(context, null, items, onSelected),
         onLongPress: triggerOnLongPress ? () => _showMenu<T>(context, null, items, onSelected) : null,
         child: child,
       ),

--- a/lib/src/widgets/adaptive_popup_menu_button.dart
+++ b/lib/src/widgets/adaptive_popup_menu_button.dart
@@ -71,6 +71,7 @@ class AdaptivePopupMenuButton<T> {
     onSelected,
     Color? tint,
     PopupButtonStyle buttonStyle = PopupButtonStyle.plain,
+    bool triggerOnLongPress = false,
     required Widget child,
   }) {
     // iOS 26+ - Use gesture detector with native menu
@@ -80,6 +81,7 @@ class AdaptivePopupMenuButton<T> {
         onSelected: onSelected,
         tint: tint,
         buttonStyle: buttonStyle,
+        triggerOnLongPress: triggerOnLongPress,
         child: child,
       );
     }
@@ -97,7 +99,8 @@ class AdaptivePopupMenuButton<T> {
     // iOS <26 (iOS 18 and below) - Use GestureDetector with action sheet
     return Builder(
       builder: (context) => GestureDetector(
-        onTap: () => _showMenu<T>(context, null, items, onSelected),
+        onTap: triggerOnLongPress ? null : () => _showMenu<T>(context, null, items, onSelected),
+        onLongPress: triggerOnLongPress ? () => _showMenu<T>(context, null, items, onSelected) : null,
         child: child,
       ),
     );
@@ -171,6 +174,7 @@ class AdaptivePopupMenuButton<T> {
               if (items[i] is AdaptivePopupMenuItem<T>)
                 CupertinoActionSheetAction(
                   onPressed: () => Navigator.of(ctx).pop(i),
+                  isDestructiveAction: (items[i] as AdaptivePopupMenuItem<T>).isDestructive,
                   child: Text((items[i] as AdaptivePopupMenuItem<T>).label),
                 )
               else
@@ -258,6 +262,9 @@ class _MaterialPopupMenuButtonState<T>
         menuItems.add(const PopupMenuDivider());
       } else if (widget.items[i] is AdaptivePopupMenuItem<T>) {
         final item = widget.items[i] as AdaptivePopupMenuItem<T>;
+        final labelStyle = item.isDestructive
+            ? const TextStyle(color: Color(0xFFD22121))
+            : null;
         menuItems.add(
           PopupMenuItem<int>(
             value: i,
@@ -270,10 +277,11 @@ class _MaterialPopupMenuButtonState<T>
                         ? item.icon as IconData
                         : Icons.circle,
                     size: 20,
+                    color: item.isDestructive ? const Color(0xFFD22121) : null,
                   ),
                   const SizedBox(width: 12),
                 ],
-                Expanded(child: Text(item.label)),
+                Expanded(child: Text(item.label, style: labelStyle)),
               ],
             ),
           ),

--- a/lib/src/widgets/ios26/ios26_popup_menu_button.dart
+++ b/lib/src/widgets/ios26/ios26_popup_menu_button.dart
@@ -98,6 +98,7 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
     this.tint,
     this.buttonStyle = PopupButtonStyle.plain,
     this.triggerOnLongPress = false,
+    this.onTap,
     required this.child,
   }) : buttonLabel = null,
        buttonIcon = null,
@@ -117,6 +118,9 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
 
   /// When true, menu shows on long press instead of tap (iOS 14+).
   final bool triggerOnLongPress;
+
+  /// Optional tap callback for widget mode — fires on regular tap when triggerOnLongPress is true.
+  final VoidCallback? onTap;
 
   /// Fixed width in icon mode
   final double? width;
@@ -348,15 +352,18 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
 
       // Custom widget mode: Stack with custom widget determining size
       if (isCustomWidget) {
-        return Stack(
-          fit: StackFit.passthrough,
-          children: [
-            widget.child!, // Determines size and is visible
-            Positioned.fill(
-              child:
-                  platformView, // Native button overlay (transparent but catches touches)
-            ),
-          ],
+        return GestureDetector(
+          onTap: widget.onTap,
+          child: Stack(
+            fit: StackFit.passthrough,
+            children: [
+              widget.child!, // Determines size and is visible
+              Positioned.fill(
+                child:
+                    platformView, // Native button overlay (transparent but catches touches)
+              ),
+            ],
+          ),
         );
       }
 

--- a/lib/src/widgets/ios26/ios26_popup_menu_button.dart
+++ b/lib/src/widgets/ios26/ios26_popup_menu_button.dart
@@ -17,6 +17,7 @@ class AdaptivePopupMenuItem<T> extends AdaptivePopupMenuEntry {
     required this.label,
     this.icon,
     this.enabled = true,
+    this.isDestructive = false,
     this.value,
   });
 
@@ -28,6 +29,9 @@ class AdaptivePopupMenuItem<T> extends AdaptivePopupMenuEntry {
 
   /// Whether the item can be selected
   final bool enabled;
+
+  /// If true, renders the item in red (destructive action styling)
+  final bool isDestructive;
 
   /// Optional value of type T associated with this item
   final T? value;
@@ -66,7 +70,8 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
   }) : buttonIcon = null,
        child = null,
        width = null,
-       round = false;
+       round = false,
+       triggerOnLongPress = false;
 
   /// Creates a round, icon-only popup menu button
   const IOS26PopupMenuButton.icon({
@@ -82,7 +87,8 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
        round = true,
        width = size,
        height = size,
-       shrinkWrap = false;
+       shrinkWrap = false,
+       triggerOnLongPress = false;
 
   /// Creates a popup menu button with a custom child widget
   const IOS26PopupMenuButton.widget({
@@ -91,6 +97,7 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
     required this.onSelected,
     this.tint,
     this.buttonStyle = PopupButtonStyle.plain,
+    this.triggerOnLongPress = false,
     required this.child,
   }) : buttonLabel = null,
        buttonIcon = null,
@@ -107,6 +114,9 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
 
   /// Custom child widget (non-null in widget mode)
   final Widget? child;
+
+  /// When true, menu shows on long press instead of tap (iOS 14+).
+  final bool triggerOnLongPress;
 
   /// Fixed width in icon mode
   final double? width;
@@ -204,6 +214,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
         if (oldItem.label != newItem.label ||
             oldItem.icon != newItem.icon ||
             oldItem.enabled != newItem.enabled ||
+            oldItem.isDestructive != newItem.isDestructive ||
             oldItem.value != newItem.value) {
           return true;
         }
@@ -221,6 +232,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
     final symbols = <String>[];
     final isDivider = <bool>[];
     final enabled = <bool>[];
+    final isDestructive = <bool>[];
 
     for (final e in widget.items) {
       if (e is AdaptivePopupMenuDivider) {
@@ -228,11 +240,13 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
         symbols.add('');
         isDivider.add(true);
         enabled.add(false);
+        isDestructive.add(false);
       } else if (e is AdaptivePopupMenuItem<T>) {
         labels.add(e.label);
         symbols.add(e.icon is String ? e.icon as String : '');
         isDivider.add(false);
         enabled.add(e.enabled);
+        isDestructive.add(e.isDestructive);
       }
     }
 
@@ -242,6 +256,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
         'sfSymbols': symbols,
         'isDivider': isDivider,
         'enabled': enabled,
+        'isDestructive': isDestructive,
       });
     } catch (_) {}
   }
@@ -270,6 +285,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
       final symbols = <String>[];
       final isDivider = <bool>[];
       final enabled = <bool>[];
+      final isDestructiveList = <bool>[];
 
       for (final e in widget.items) {
         if (e is AdaptivePopupMenuDivider) {
@@ -277,11 +293,13 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
           symbols.add('');
           isDivider.add(true);
           enabled.add(false);
+          isDestructiveList.add(false);
         } else if (e is AdaptivePopupMenuItem<T>) {
           labels.add(e.label);
           symbols.add(e.icon is String ? e.icon as String : '');
           isDivider.add(false);
           enabled.add(e.enabled);
+          isDestructiveList.add(e.isDestructive);
         }
       }
 
@@ -290,11 +308,13 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
         if (widget.buttonIcon != null) 'buttonIconName': widget.buttonIcon,
         if (widget.isIconButton) 'round': true,
         if (isCustomWidget) 'customWidget': true, // Hide native button content
+        if (widget.triggerOnLongPress) 'triggerOnLongPress': true,
         'buttonStyle': widget.buttonStyle.name,
         'labels': labels,
         'sfSymbols': symbols,
         'isDivider': isDivider,
         'enabled': enabled,
+        'isDestructive': isDestructiveList,
         'isDark': _isDark,
         if (_effectiveTint != null) 'tint': _colorToARGB(_effectiveTint!),
       };
@@ -320,7 +340,9 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
         creationParamsCodec: const StandardMessageCodec(),
         onPlatformViewCreated: _onCreated,
         gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{
-          Factory<TapGestureRecognizer>(() => TapGestureRecognizer()),
+          widget.triggerOnLongPress
+              ? Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer())
+              : Factory<TapGestureRecognizer>(() => TapGestureRecognizer()),
         },
       );
 
@@ -478,6 +500,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
               if (widget.items[i] is AdaptivePopupMenuItem<T>)
                 CupertinoActionSheetAction(
                   onPressed: () => Navigator.of(ctx).pop(i),
+                  isDestructiveAction: (widget.items[i] as AdaptivePopupMenuItem<T>).isDestructive,
                   child: Text(
                     (widget.items[i] as AdaptivePopupMenuItem<T>).label,
                   ),

--- a/lib/src/widgets/ios26/ios26_popup_menu_button.dart
+++ b/lib/src/widgets/ios26/ios26_popup_menu_button.dart
@@ -354,18 +354,21 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
 
       // Custom widget mode: Stack with custom widget determining size
       if (isCustomWidget) {
-        return GestureDetector(
-          onTap: widget.onTap,
-          child: Stack(
-            fit: StackFit.passthrough,
-            children: [
-              widget.child!, // Determines size and is visible
+        return Stack(
+          fit: StackFit.passthrough,
+          children: [
+            widget.child!, // Determines size and is visible
+            Positioned.fill(
+              child: platformView, // Native button overlay catches long-press
+            ),
+            if (widget.onTap != null)
               Positioned.fill(
-                child:
-                    platformView, // Native button overlay (transparent but catches touches)
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTap: widget.onTap,
+                ),
               ),
-            ],
-          ),
+          ],
         );
       }
 

--- a/lib/src/widgets/ios26/ios26_popup_menu_button.dart
+++ b/lib/src/widgets/ios26/ios26_popup_menu_button.dart
@@ -71,7 +71,8 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
        child = null,
        width = null,
        round = false,
-       triggerOnLongPress = false;
+       triggerOnLongPress = false,
+       onTap = null;
 
   /// Creates a round, icon-only popup menu button
   const IOS26PopupMenuButton.icon({
@@ -88,7 +89,8 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
        width = size,
        height = size,
        shrinkWrap = false,
-       triggerOnLongPress = false;
+       triggerOnLongPress = false,
+       onTap = null;
 
   /// Creates a popup menu button with a custom child widget
   const IOS26PopupMenuButton.widget({


### PR DESCRIPTION
## Summary

- Remove `.clamp(0.0, 1.0)` from `IOSSpringCurve.transformInternal` — the clamp prevents the spring from overshooting, which kills the underdamped bounce effect that is the whole point of using a spring curve.
- Export `IOSSpringCurve` from the public barrel `lib/adaptive_platform_ui.dart` — it was only reachable via an internal `src/` path, making it inaccessible to package consumers.

## Test plan

- [ ] Verify spring press animations visibly overshoot (bounce) instead of stopping flat at the target value
- [ ] Verify `import 'package:adaptive_platform_ui/adaptive_platform_ui.dart'` exposes `IOSSpringCurve` without a separate `src/` import

🤖 Generated with [Claude Code](https://claude.ai/claude-code)