### PR TITLE
fix: alert dialog tint color respects CupertinoTheme primaryColor instead of hardcoded systemBlue

### DIFF
--- a/ios/Classes/iOS26AlertDialogView.swift
+++ b/ios/Classes/iOS26AlertDialogView.swift
@@ -508,7 +508,7 @@ class iOS26AlertDialogView: NSObject, FlutterPlatformView {
         // alert tint to red when no primary action is present.
         if let action = primaryAction {
             alert.preferredAction = action
-            alert.view.tintColor = UIColor.systemBlue
+            alert.view.tintColor = tint ?? UIColor.systemBlue
         }
 
         // Present the alert


### PR DESCRIPTION
## Summary
The `IOS26AlertDialogView` currently hardcodes `UIColor.systemBlue` as the alert tint color on line 511, which overrides the custom tint passed from the Dart side via `CupertinoTheme.of(context).primaryColor`. This means apps with custom theme colors cannot style their alert dialogs.

## Fix
Change line 511 from `alert.view.tintColor = UIColor.systemBlue` to `alert.view.tintColor = tint ?? UIColor.systemBlue`, so the custom tint is respected when provided, falling back to systemBlue only when no custom tint is set.

## Testing
- Verified on iOS 26: alert button colors now follow the app's CupertinoTheme primaryColor
- Without custom tint: falls back to systemBlue (backward compatible)