### PR TITLE
Fix: IOSSpringCurve overshoot + expose it publicly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.1.109]
+* **FIX**: `IOSSpringCurve` no longer clamps its output to [0,1], restoring the natural spring overshoot in the mid-range (endpoints remain exact) (@yuriylybimov)
+* **NEW**: Exported `IOSSpringCurve` from the package's public API (@yuriylybimov)
+
 ## [0.1.108]
 * **IMPROVEMENT**: Migrated the iOS plugin from CocoaPods to Swift Package Manager — apps with SPM enabled (`flutter config --enable-swift-package-manager`) now consume the plugin as a Swift package, while CocoaPods-based projects keep working unchanged (@philipgiuliani)
 * **IMPROVEMENT**: Raised the iOS minimum deployment target from 12.0 to 13.0, matching Flutter's supported minimum (@philipgiuliani)

--- a/lib/adaptive_platform_ui.dart
+++ b/lib/adaptive_platform_ui.dart
@@ -30,6 +30,9 @@ library;
 // Platform utilities
 export 'src/platform/platform_info.dart';
 
+// Animation utilities
+export 'src/utils/animation.dart';
+
 // Styles
 export 'src/style/sf_symbol.dart';
 

--- a/lib/src/utils/animation.dart
+++ b/lib/src/utils/animation.dart
@@ -20,6 +20,6 @@ class IOSSpringCurve extends Curve {
     // Simulate over a fixed duration window (e.g. 1.5s)
     // t is [0,1], so we map it into the spring's time domain
     final sim = SpringSimulation(spring, 0, 1, 0);
-    return sim.x(t * 1.5).clamp(0.0, 1.0);
+    return sim.x(t * 1.5);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adaptive_platform_ui
 description: "Adaptive platform-specific widgets for Flutter. Auto renders native iOS 26+ liquid glass designs, traditional Cupertino widgets for older iOS versions, Material Design for Android."
-version: 0.1.108
+version: 0.1.109
 homepage: https://github.com/berkaycatak/adaptive_platform_ui
 screenshots:
   - description: "iOS 26+ liquid glass designs"

--- a/test/ios_spring_curve_test.dart
+++ b/test/ios_spring_curve_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+// Import via the public barrel — this also proves IOSSpringCurve is exported.
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+
+void main() {
+  group('IOSSpringCurve', () {
+    const curve = IOSSpringCurve();
+
+    test('endpoints are exact', () {
+      // Curve.transform short-circuits the exact endpoints.
+      expect(curve.transform(0.0), 0.0);
+      expect(curve.transform(1.0), 1.0);
+    });
+
+    test('overshoots above 1.0 in the mid-range (clamp regression guard)', () {
+      // The spring is underdamped (damping ratio ~0.9), so the simulation
+      // overshoots its target before settling. This is the regression guard
+      // for the removed `.clamp(0, 1)` — if it is ever re-added, this fails.
+      final samples = <double, double>{};
+      for (var i = 1; i <= 19; i++) {
+        final t = i * 0.05; // 0.05 .. 0.95
+        samples[t] = curve.transform(t);
+      }
+      final overshot = samples.values.any((v) => v > 1.0);
+      expect(
+        overshot,
+        isTrue,
+        reason: 'expected at least one sample > 1.0, got: $samples',
+      );
+    });
+
+    test('all sampled values are finite', () {
+      for (var i = 0; i <= 20; i++) {
+        final t = i * 0.05; // 0.0 .. 1.0
+        final v = curve.transform(t);
+        expect(v.isFinite, isTrue, reason: 'transform($t) = $v is not finite');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Description
Removes the `.clamp(0.0, 1.0)` from `IOSSpringCurve.transformInternal`, which was flattening the spring's natural mid-range overshoot (the slight bounce past 1.0 that makes an iOS spring feel alive). Endpoints are unaffected - Flutter's `Curve.transform` short-circuits t==0 and t==1 to exact values, so only the in-between is restored. Also exports `IOSSpringCurve` from the package's public API.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
<!-- Link any related issues here -->

## Changes Made
- Removed the output clamp from `IOSSpringCurve.transformInternal`, restoring spring overshoot
- Exported `IOSSpringCurve` from the package barrel (`adaptive_platform_ui.dart`)
- Added a unit test (endpoints exact, overshoot present, finite across range)
- CHANGELOG entry + version bump to 0.1.109

## Testing

### Automated Tests ⚠️ **REQUIRED**
- [x] I have added unit/widget tests for my changes
- [x] All new and existing tests pass locally (`flutter test`)
- [x] Code analysis passes with no errors (`flutter analyze`)
- [x] Code formatting is correct (`dart format`)
- [ ] Test coverage is adequate (>80% for new code)

### Manual Testing
(No UI change — this is a pure animation-curve math fix; no per-platform manual testing applies.)
- [ ] iOS 26+ tested
- [ ] iOS <26 tested
- [ ] Android tested
- [ ] Web tested (if applicable)
- [ ] Tested in both light and dark mode
- [ ] Tested with different screen sizes
- [ ] Tested with accessibility features (large fonts, screen readers, etc.)

## Checklist
<!-- Please check all that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have checked that my code does not introduce any accessibility issues
- [x] I have updated the CHANGELOG.md file (if applicable)
- [x] I have updated version number in pubspec.yaml (if applicable)
- [ ] I have added examples to the example app (if adding new widgets)

## Additional Notes
The export is what lets consumers actually use `IOSSpringCurve`; the clamp removal is the behavioral fix. The added test fails if the clamp is ever reintroduced.
