### PR TITLE
Popup menu: triggerOnLongPress + onTap, and isDestructive across all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.1.109]
+* **NEW**: `triggerOnLongPress` and `onTap` on popup menu buttons — tap fires `onTap`, long-press opens the menu (@yuriylybimov)
+* **NEW**: `isDestructive` on `AdaptivePopupMenuItem` — renders destructive styling on Material and iOS <26 (@yuriylybimov)
+* **FIX**: destructive menu items now use the theme `colorScheme.error` instead of a hardcoded red (@yuriylybimov)
+
 ## [0.1.108]
 * **IMPROVEMENT**: Migrated the iOS plugin from CocoaPods to Swift Package Manager — apps with SPM enabled (`flutter config --enable-swift-package-manager`) now consume the plugin as a Swift package, while CocoaPods-based projects keep working unchanged (@philipgiuliani)
 * **IMPROVEMENT**: Raised the iOS minimum deployment target from 12.0 to 13.0, matching Flutter's supported minimum (@philipgiuliani)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.1.109]
 * **NEW**: `triggerOnLongPress` and `onTap` on popup menu buttons — tap fires `onTap`, long-press opens the menu (@yuriylybimov)
-* **NEW**: `isDestructive` on `AdaptivePopupMenuItem` — renders destructive styling on Material and iOS <26 (@yuriylybimov)
+* **NEW**: `isDestructive` on `AdaptivePopupMenuItem` — renders destructive (red) styling on Material, iOS <26, and iOS 26+ native menus (@yuriylybimov)
 * **FIX**: destructive menu items now use the theme `colorScheme.error` instead of a hardcoded red (@yuriylybimov)
 
 ## [0.1.108]

--- a/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26PopupMenuButtonView.swift
+++ b/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26PopupMenuButtonView.swift
@@ -12,6 +12,7 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
     private var symbols: [String] = []
     private var dividers: [Bool] = []
     private var enabled: [Bool] = []
+    private var isDestructive: [Bool] = []
 
     init(frame: CGRect, viewId: Int64, args: Any?, messenger: FlutterBinaryMessenger) {
         self.channel = FlutterMethodChannel(name: "adaptive_platform_ui/ios26_popup_menu_button_\(viewId)", binaryMessenger: messenger)
@@ -28,6 +29,7 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
         var symbols: [String] = []
         var dividers: [NSNumber] = []
         var enabled: [NSNumber] = []
+        var isDestructive: [NSNumber] = []
         var isCustomWidget: Bool = false
         var triggerOnLongPress: Bool = false
 
@@ -44,6 +46,7 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
             symbols = (dict["sfSymbols"] as? [String]) ?? []
             dividers = (dict["isDivider"] as? [NSNumber]) ?? []
             enabled = (dict["enabled"] as? [NSNumber]) ?? []
+            isDestructive = (dict["isDestructive"] as? [NSNumber]) ?? []
         }
 
         super.init()
@@ -72,6 +75,7 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
         self.symbols = symbols
         self.dividers = dividers.map { $0.boolValue }
         self.enabled = enabled.map { $0.boolValue }
+        self.isDestructive = isDestructive.map { $0.boolValue }
 
         self.isRoundButton = makeRound
         currentButtonStyle = buttonStyle
@@ -130,6 +134,7 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
                     self.symbols = (args["sfSymbols"] as? [String]) ?? []
                     self.dividers = ((args["isDivider"] as? [NSNumber]) ?? []).map { $0.boolValue }
                     self.enabled = ((args["enabled"] as? [NSNumber]) ?? []).map { $0.boolValue }
+                    self.isDestructive = ((args["isDestructive"] as? [NSNumber]) ?? []).map { $0.boolValue }
                     self.rebuildMenu()
                     result(nil)
                 } else { result(FlutterError(code: "bad_args", message: "Missing menu items", details: nil)) }
@@ -173,10 +178,13 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
                 }
 
                 let isEnabled = i < enabled.count ? enabled[i] : true
+                let isDestructiveItem = i < isDestructive.count ? isDestructive[i] : false
                 let currentSelectableIndex = selectableIndex
                 selectableIndex += 1
 
-                let action = UIAction(title: title, image: image, attributes: isEnabled ? [] : [.disabled]) { [weak self] _ in
+                var attrs: UIMenuElement.Attributes = isEnabled ? [] : [.disabled]
+                if isDestructiveItem { attrs.insert(.destructive) }
+                let action = UIAction(title: title, image: image, attributes: attrs) { [weak self] _ in
                     self?.channel.invokeMethod("itemSelected", arguments: ["index": currentSelectableIndex])
                 }
                 current.append(action)
@@ -205,10 +213,11 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
             }
 
             let title = i < labels.count ? labels[i] : ""
+            let isDestructiveItem = i < isDestructive.count ? isDestructive[i] : false
             let currentSelectableIndex = selectableIndex
             selectableIndex += 1
 
-            let action = UIAlertAction(title: title, style: .default) { [weak self] _ in
+            let action = UIAlertAction(title: title, style: isDestructiveItem ? .destructive : .default) { [weak self] _ in
                 self?.channel.invokeMethod("itemSelected", arguments: ["index": currentSelectableIndex])
             }
 

--- a/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26PopupMenuButtonView.swift
+++ b/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26PopupMenuButtonView.swift
@@ -29,6 +29,7 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
         var dividers: [NSNumber] = []
         var enabled: [NSNumber] = []
         var isCustomWidget: Bool = false
+        var triggerOnLongPress: Bool = false
 
         if let dict = args as? [String: Any] {
             if let t = dict["buttonTitle"] as? String { title = t }
@@ -38,6 +39,7 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
             if let tintArgb = dict["tint"] as? NSNumber { tint = UIColor(argb: tintArgb.intValue) }
             if let bs = dict["buttonStyle"] as? String { buttonStyle = bs }
             if let cw = dict["customWidget"] as? NSNumber { isCustomWidget = cw.boolValue }
+            if let lp = dict["triggerOnLongPress"] as? NSNumber { triggerOnLongPress = lp.boolValue }
             labels = (dict["labels"] as? [String]) ?? []
             symbols = (dict["sfSymbols"] as? [String]) ?? []
             dividers = (dict["isDivider"] as? [NSNumber]) ?? []
@@ -94,7 +96,7 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
         rebuildMenu()
 
         if #available(iOS 14.0, *) {
-            button.showsMenuAsPrimaryAction = true
+            button.showsMenuAsPrimaryAction = !triggerOnLongPress
         } else {
             button.addTarget(self, action: #selector(onButtonPressedLegacy(_:)), for: .touchUpInside)
         }

--- a/lib/src/widgets/adaptive_popup_menu_button.dart
+++ b/lib/src/widgets/adaptive_popup_menu_button.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import '../platform/platform_info.dart';
 import 'ios26/ios26_popup_menu_button.dart';
@@ -76,6 +75,11 @@ class AdaptivePopupMenuButton<T> {
     VoidCallback? onTap,
     required Widget child,
   }) {
+    assert(
+      onTap == null || triggerOnLongPress,
+      'onTap is only used with triggerOnLongPress: true (tap fires onTap, '
+      'long-press opens the menu).',
+    );
     // iOS 26+ - Use gesture detector with native menu
     if (PlatformInfo.isIOS26OrHigher()) {
       return IOS26PopupMenuButton<T>.widget(
@@ -266,7 +270,7 @@ class _MaterialPopupMenuButtonState<T>
       } else if (widget.items[i] is AdaptivePopupMenuItem<T>) {
         final item = widget.items[i] as AdaptivePopupMenuItem<T>;
         final labelStyle = item.isDestructive
-            ? const TextStyle(color: Color(0xFFD22121))
+            ? TextStyle(color: Theme.of(context).colorScheme.error)
             : null;
         menuItems.add(
           PopupMenuItem<int>(
@@ -280,7 +284,9 @@ class _MaterialPopupMenuButtonState<T>
                         ? item.icon as IconData
                         : Icons.circle,
                     size: 20,
-                    color: item.isDestructive ? const Color(0xFFD22121) : null,
+                    color: item.isDestructive
+                        ? Theme.of(context).colorScheme.error
+                        : null,
                   ),
                   const SizedBox(width: 12),
                 ],

--- a/lib/src/widgets/adaptive_popup_menu_button.dart
+++ b/lib/src/widgets/adaptive_popup_menu_button.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import '../platform/platform_info.dart';
 import 'ios26/ios26_popup_menu_button.dart';
@@ -72,6 +73,7 @@ class AdaptivePopupMenuButton<T> {
     Color? tint,
     PopupButtonStyle buttonStyle = PopupButtonStyle.plain,
     bool triggerOnLongPress = false,
+    VoidCallback? onTap,
     required Widget child,
   }) {
     // iOS 26+ - Use gesture detector with native menu
@@ -82,6 +84,7 @@ class AdaptivePopupMenuButton<T> {
         tint: tint,
         buttonStyle: buttonStyle,
         triggerOnLongPress: triggerOnLongPress,
+        onTap: onTap,
         child: child,
       );
     }
@@ -99,7 +102,7 @@ class AdaptivePopupMenuButton<T> {
     // iOS <26 (iOS 18 and below) - Use GestureDetector with action sheet
     return Builder(
       builder: (context) => GestureDetector(
-        onTap: triggerOnLongPress ? null : () => _showMenu<T>(context, null, items, onSelected),
+        onTap: triggerOnLongPress ? onTap : () => _showMenu<T>(context, null, items, onSelected),
         onLongPress: triggerOnLongPress ? () => _showMenu<T>(context, null, items, onSelected) : null,
         child: child,
       ),

--- a/lib/src/widgets/adaptive_popup_menu_button.dart
+++ b/lib/src/widgets/adaptive_popup_menu_button.dart
@@ -71,6 +71,7 @@ class AdaptivePopupMenuButton<T> {
     onSelected,
     Color? tint,
     PopupButtonStyle buttonStyle = PopupButtonStyle.plain,
+    bool triggerOnLongPress = false,
     required Widget child,
   }) {
     // iOS 26+ - Use gesture detector with native menu
@@ -80,6 +81,7 @@ class AdaptivePopupMenuButton<T> {
         onSelected: onSelected,
         tint: tint,
         buttonStyle: buttonStyle,
+        triggerOnLongPress: triggerOnLongPress,
         child: child,
       );
     }
@@ -97,7 +99,8 @@ class AdaptivePopupMenuButton<T> {
     // iOS <26 (iOS 18 and below) - Use GestureDetector with action sheet
     return Builder(
       builder: (context) => GestureDetector(
-        onTap: () => _showMenu<T>(context, null, items, onSelected),
+        onTap: triggerOnLongPress ? null : () => _showMenu<T>(context, null, items, onSelected),
+        onLongPress: triggerOnLongPress ? () => _showMenu<T>(context, null, items, onSelected) : null,
         child: child,
       ),
     );
@@ -171,6 +174,7 @@ class AdaptivePopupMenuButton<T> {
               if (items[i] is AdaptivePopupMenuItem<T>)
                 CupertinoActionSheetAction(
                   onPressed: () => Navigator.of(ctx).pop(i),
+                  isDestructiveAction: (items[i] as AdaptivePopupMenuItem<T>).isDestructive,
                   child: Text((items[i] as AdaptivePopupMenuItem<T>).label),
                 )
               else
@@ -258,6 +262,9 @@ class _MaterialPopupMenuButtonState<T>
         menuItems.add(const PopupMenuDivider());
       } else if (widget.items[i] is AdaptivePopupMenuItem<T>) {
         final item = widget.items[i] as AdaptivePopupMenuItem<T>;
+        final labelStyle = item.isDestructive
+            ? const TextStyle(color: Color(0xFFD22121))
+            : null;
         menuItems.add(
           PopupMenuItem<int>(
             value: i,
@@ -270,10 +277,11 @@ class _MaterialPopupMenuButtonState<T>
                         ? item.icon as IconData
                         : Icons.circle,
                     size: 20,
+                    color: item.isDestructive ? const Color(0xFFD22121) : null,
                   ),
                   const SizedBox(width: 12),
                 ],
-                Expanded(child: Text(item.label)),
+                Expanded(child: Text(item.label, style: labelStyle)),
               ],
             ),
           ),

--- a/lib/src/widgets/ios26/ios26_popup_menu_button.dart
+++ b/lib/src/widgets/ios26/ios26_popup_menu_button.dart
@@ -98,6 +98,7 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
     this.tint,
     this.buttonStyle = PopupButtonStyle.plain,
     this.triggerOnLongPress = false,
+    this.onTap,
     required this.child,
   }) : buttonLabel = null,
        buttonIcon = null,
@@ -117,6 +118,9 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
 
   /// When true, menu shows on long press instead of tap (iOS 14+).
   final bool triggerOnLongPress;
+
+  /// Optional tap callback for widget mode — fires on regular tap when triggerOnLongPress is true.
+  final VoidCallback? onTap;
 
   /// Fixed width in icon mode
   final double? width;
@@ -348,15 +352,18 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
 
       // Custom widget mode: Stack with custom widget determining size
       if (isCustomWidget) {
-        return Stack(
-          fit: StackFit.passthrough,
-          children: [
-            widget.child!, // Determines size and is visible
-            Positioned.fill(
-              child:
-                  platformView, // Native button overlay (transparent but catches touches)
-            ),
-          ],
+        return GestureDetector(
+          onTap: widget.onTap,
+          child: Stack(
+            fit: StackFit.passthrough,
+            children: [
+              widget.child!, // Determines size and is visible
+              Positioned.fill(
+                child:
+                    platformView, // Native button overlay (transparent but catches touches)
+              ),
+            ],
+          ),
         );
       }
 

--- a/lib/src/widgets/ios26/ios26_popup_menu_button.dart
+++ b/lib/src/widgets/ios26/ios26_popup_menu_button.dart
@@ -17,6 +17,7 @@ class AdaptivePopupMenuItem<T> extends AdaptivePopupMenuEntry {
     required this.label,
     this.icon,
     this.enabled = true,
+    this.isDestructive = false,
     this.value,
   });
 
@@ -28,6 +29,9 @@ class AdaptivePopupMenuItem<T> extends AdaptivePopupMenuEntry {
 
   /// Whether the item can be selected
   final bool enabled;
+
+  /// If true, renders the item in red (destructive action styling)
+  final bool isDestructive;
 
   /// Optional value of type T associated with this item
   final T? value;
@@ -66,7 +70,8 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
   }) : buttonIcon = null,
        child = null,
        width = null,
-       round = false;
+       round = false,
+       triggerOnLongPress = false;
 
   /// Creates a round, icon-only popup menu button
   const IOS26PopupMenuButton.icon({
@@ -82,7 +87,8 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
        round = true,
        width = size,
        height = size,
-       shrinkWrap = false;
+       shrinkWrap = false,
+       triggerOnLongPress = false;
 
   /// Creates a popup menu button with a custom child widget
   const IOS26PopupMenuButton.widget({
@@ -91,6 +97,7 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
     required this.onSelected,
     this.tint,
     this.buttonStyle = PopupButtonStyle.plain,
+    this.triggerOnLongPress = false,
     required this.child,
   }) : buttonLabel = null,
        buttonIcon = null,
@@ -107,6 +114,9 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
 
   /// Custom child widget (non-null in widget mode)
   final Widget? child;
+
+  /// When true, menu shows on long press instead of tap (iOS 14+).
+  final bool triggerOnLongPress;
 
   /// Fixed width in icon mode
   final double? width;
@@ -204,6 +214,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
         if (oldItem.label != newItem.label ||
             oldItem.icon != newItem.icon ||
             oldItem.enabled != newItem.enabled ||
+            oldItem.isDestructive != newItem.isDestructive ||
             oldItem.value != newItem.value) {
           return true;
         }
@@ -221,6 +232,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
     final symbols = <String>[];
     final isDivider = <bool>[];
     final enabled = <bool>[];
+    final isDestructive = <bool>[];
 
     for (final e in widget.items) {
       if (e is AdaptivePopupMenuDivider) {
@@ -228,11 +240,13 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
         symbols.add('');
         isDivider.add(true);
         enabled.add(false);
+        isDestructive.add(false);
       } else if (e is AdaptivePopupMenuItem<T>) {
         labels.add(e.label);
         symbols.add(e.icon is String ? e.icon as String : '');
         isDivider.add(false);
         enabled.add(e.enabled);
+        isDestructive.add(e.isDestructive);
       }
     }
 
@@ -242,6 +256,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
         'sfSymbols': symbols,
         'isDivider': isDivider,
         'enabled': enabled,
+        'isDestructive': isDestructive,
       });
     } catch (_) {}
   }
@@ -270,6 +285,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
       final symbols = <String>[];
       final isDivider = <bool>[];
       final enabled = <bool>[];
+      final isDestructiveList = <bool>[];
 
       for (final e in widget.items) {
         if (e is AdaptivePopupMenuDivider) {
@@ -277,11 +293,13 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
           symbols.add('');
           isDivider.add(true);
           enabled.add(false);
+          isDestructiveList.add(false);
         } else if (e is AdaptivePopupMenuItem<T>) {
           labels.add(e.label);
           symbols.add(e.icon is String ? e.icon as String : '');
           isDivider.add(false);
           enabled.add(e.enabled);
+          isDestructiveList.add(e.isDestructive);
         }
       }
 
@@ -290,11 +308,13 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
         if (widget.buttonIcon != null) 'buttonIconName': widget.buttonIcon,
         if (widget.isIconButton) 'round': true,
         if (isCustomWidget) 'customWidget': true, // Hide native button content
+        if (widget.triggerOnLongPress) 'triggerOnLongPress': true,
         'buttonStyle': widget.buttonStyle.name,
         'labels': labels,
         'sfSymbols': symbols,
         'isDivider': isDivider,
         'enabled': enabled,
+        'isDestructive': isDestructiveList,
         'isDark': _isDark,
         if (_effectiveTint != null) 'tint': _colorToARGB(_effectiveTint!),
       };
@@ -320,7 +340,9 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
         creationParamsCodec: const StandardMessageCodec(),
         onPlatformViewCreated: _onCreated,
         gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{
-          Factory<TapGestureRecognizer>(() => TapGestureRecognizer()),
+          widget.triggerOnLongPress
+              ? Factory<LongPressGestureRecognizer>(() => LongPressGestureRecognizer())
+              : Factory<TapGestureRecognizer>(() => TapGestureRecognizer()),
         },
       );
 
@@ -478,6 +500,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
               if (widget.items[i] is AdaptivePopupMenuItem<T>)
                 CupertinoActionSheetAction(
                   onPressed: () => Navigator.of(ctx).pop(i),
+                  isDestructiveAction: (widget.items[i] as AdaptivePopupMenuItem<T>).isDestructive,
                   child: Text(
                     (widget.items[i] as AdaptivePopupMenuItem<T>).label,
                   ),

--- a/lib/src/widgets/ios26/ios26_popup_menu_button.dart
+++ b/lib/src/widgets/ios26/ios26_popup_menu_button.dart
@@ -107,7 +107,12 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
        round = false,
        width = null,
        height = 32.0,
-       shrinkWrap = true;
+       shrinkWrap = true,
+       assert(
+         onTap == null || triggerOnLongPress,
+         'onTap is only used with triggerOnLongPress: true (tap fires onTap, '
+         'long-press opens the menu).',
+       );
 
   /// Text for the button (null when using icon)
   final String? buttonLabel;
@@ -121,7 +126,10 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
   /// When true, menu shows on long press instead of tap (iOS 14+).
   final bool triggerOnLongPress;
 
-  /// Optional tap callback for widget mode — fires on regular tap when triggerOnLongPress is true.
+  /// Optional tap callback for widget mode. Pairs with [triggerOnLongPress]:
+  /// when `triggerOnLongPress` is true, a regular tap fires this callback while
+  /// a long-press opens the menu. Has no effect unless `triggerOnLongPress` is
+  /// true (asserted in the constructor).
   final VoidCallback? onTap;
 
   /// Fixed width in icon mode
@@ -361,7 +369,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
             Positioned.fill(
               child: platformView, // Native button overlay catches long-press
             ),
-            if (widget.onTap != null)
+            if (widget.triggerOnLongPress && widget.onTap != null)
               Positioned.fill(
                 child: GestureDetector(
                   behavior: HitTestBehavior.translucent,

--- a/lib/src/widgets/ios26/ios26_popup_menu_button.dart
+++ b/lib/src/widgets/ios26/ios26_popup_menu_button.dart
@@ -354,18 +354,21 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
 
       // Custom widget mode: Stack with custom widget determining size
       if (isCustomWidget) {
-        return GestureDetector(
-          onTap: widget.onTap,
-          child: Stack(
-            fit: StackFit.passthrough,
-            children: [
-              widget.child!, // Determines size and is visible
+        return Stack(
+          fit: StackFit.passthrough,
+          children: [
+            widget.child!, // Determines size and is visible
+            Positioned.fill(
+              child: platformView, // Native button overlay catches long-press
+            ),
+            if (widget.onTap != null)
               Positioned.fill(
-                child:
-                    platformView, // Native button overlay (transparent but catches touches)
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTap: widget.onTap,
+                ),
               ),
-            ],
-          ),
+          ],
         );
       }
 

--- a/lib/src/widgets/ios26/ios26_popup_menu_button.dart
+++ b/lib/src/widgets/ios26/ios26_popup_menu_button.dart
@@ -71,7 +71,8 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
        child = null,
        width = null,
        round = false,
-       triggerOnLongPress = false;
+       triggerOnLongPress = false,
+       onTap = null;
 
   /// Creates a round, icon-only popup menu button
   const IOS26PopupMenuButton.icon({
@@ -88,7 +89,8 @@ class IOS26PopupMenuButton<T> extends StatefulWidget {
        width = size,
        height = size,
        shrinkWrap = false,
-       triggerOnLongPress = false;
+       triggerOnLongPress = false,
+       onTap = null;
 
   /// Creates a popup menu button with a custom child widget
   const IOS26PopupMenuButton.widget({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adaptive_platform_ui
 description: "Adaptive platform-specific widgets for Flutter. Auto renders native iOS 26+ liquid glass designs, traditional Cupertino widgets for older iOS versions, Material Design for Android."
-version: 0.1.108
+version: 0.1.109
 homepage: https://github.com/berkaycatak/adaptive_platform_ui
 screenshots:
   - description: "iOS 26+ liquid glass designs"

--- a/test/adaptive_popup_menu_test.dart
+++ b/test/adaptive_popup_menu_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+// Public barrel only — these are the symbols consumers actually import.
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+
+void main() {
+  group('AdaptivePopupMenuItem.isDestructive', () {
+    test('defaults to false', () {
+      const item = AdaptivePopupMenuItem<String>(label: 'Edit');
+      expect(item.isDestructive, isFalse);
+    });
+
+    test('stores true when set', () {
+      const item = AdaptivePopupMenuItem<String>(
+        label: 'Delete',
+        isDestructive: true,
+      );
+      expect(item.isDestructive, isTrue);
+    });
+  });
+
+  group('AdaptivePopupMenuButton.widget onTap/triggerOnLongPress guard', () {
+    // The assert lives at the public dispatch point (AdaptivePopupMenuButton.widget),
+    // so the contract is enforced uniformly on every platform path — not just the
+    // iOS-26 native path. This is the load-bearing case consumers actually touch.
+    const items = <AdaptivePopupMenuEntry>[
+      AdaptivePopupMenuItem<String>(label: 'One'),
+    ];
+    void onSelected(int index, AdaptivePopupMenuItem<String> entry) {}
+
+    test('throws when onTap is set without triggerOnLongPress', () {
+      expect(
+        () => AdaptivePopupMenuButton.widget<String>(
+          items: items,
+          onSelected: onSelected,
+          onTap: () {},
+          child: const SizedBox(),
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    test('does not throw when onTap pairs with triggerOnLongPress: true', () {
+      expect(
+        () => AdaptivePopupMenuButton.widget<String>(
+          items: items,
+          onSelected: onSelected,
+          triggerOnLongPress: true,
+          onTap: () {},
+          child: const SizedBox(),
+        ),
+        returnsNormally,
+      );
+    });
+
+    test('does not throw when onTap is null', () {
+      expect(
+        () => AdaptivePopupMenuButton.widget<String>(
+          items: items,
+          onSelected: onSelected,
+          child: const SizedBox(),
+        ),
+        returnsNormally,
+      );
+    });
+  });
+
+  // NOTE: the Material destructive-color fix (colorScheme.error) is intentionally
+  // NOT covered here. That path lives in the private _MaterialPopupMenuButton and is
+  // only selected when PlatformInfo.isAndroid — which reads the real host OS via
+  // dart:io (ignores debugDefaultTargetPlatformOverride), so it's unreachable in a
+  // host widget test. The color change is covered by code review + CHANGELOG.
+}


### PR DESCRIPTION
## Description
Adds two popup-menu capabilities and completes destructive-item styling across all platforms.

- `triggerOnLongPress` + `onTap` on popup menu buttons: a tap fires `onTap` (e.g. opens the item) while a long-press opens the menu. Guarded by an assert at the public dispatch point so passing `onTap` without `triggerOnLongPress` can't silently drop the callback.
- `isDestructive` on `AdaptivePopupMenuItem`, now honored on every path: Material (`Theme.of(context).colorScheme.error`), iOS <26 (`isDestructiveAction` on the Cupertino action sheet), and iOS 26+ native menus + the legacy action sheet (`.destructive` attribute/style). Previously the flag was sent over the channel but ignored natively.
  
 This is the popup-menu half of an earlier combined branch, split into two PRs per review.

## Type of Change
<!-- Please check the relevant option(s) -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
<!-- Link any related issues here -->

## Changes Made
- Added `triggerOnLongPress` and `onTap` to the popup menu button (public + iOS 26 widget API)
- Added an assert guarding `onTap` to require `triggerOnLongPress`
- Added `isDestructive` to `AdaptivePopupMenuItem`; applied it on Material, iOS <26, iOS 26+ native, and the legacy action sheet
- Replaced a hardcoded destructive red with `Theme.of(context).colorScheme.error`
- Removed a redundant `foundation.dart` import
- Added tests (isDestructive flag/default, onTap/triggerOnLongPress assert guard)
- CHANGELOG entry + version bump to 0.1.109

## Testing

### Automated Tests ⚠️ **REQUIRED**
- [x] I have added unit/widget tests for my changes
- [x] All new and existing tests pass locally (`flutter test`)
- [x] Code analysis passes with no errors (`flutter analyze`)
- [x] Code formatting is correct (`dart format`)
- [ ] Test coverage is adequate (>80% for new code)

### Manual Testing
<!-- Check all platforms where you've manually tested these changes -->
- [ ] iOS 26+ tested
- [ ] iOS <26 tested
- [ ] Android tested
- [ ] Web tested (if applicable)
- [ ] Tested in both light and dark mode
- [ ] Tested with different screen sizes
- [ ] Tested with accessibility features (large fonts, screen readers, etc.)

The iOS 26+ native path runs through a `UiKitView`, which can't be exercised in host widget tests, so it was verified by a full `flutter build ios --no-codesign` compile of the example app rather than a runtime/device test. The Dart-side behavior (flag propagation and the assert guard) is covered by widget tests. I haven't done device-level manual passes across the platform/appearance matrix above - happy to if you'd like specific cases checked.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have checked that my code does not introduce any accessibility issues
- [x] I have updated the CHANGELOG.md file (if applicable)
- [x] I have updated version number in pubspec.yaml (if applicable)
- [ ] I have added examples to the example app (if adding new widgets)

## Additional Notes
Splitting context: the spring-curve fix from the same original branch is submitted separately.
Both PRs currently bump to 0.1.109; whichever merges second will need a trivial re-bump.