### PR TITLE
feat(tab bar): customizable iOS 26 badge (text + colors) for dot indicators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+* **NEW**: `AdaptiveNavigationDestination` gains `badgeText`, `badgeColor`, and `badgeTextColor` for full control over the iOS 26+ native tab bar badge. `badgeText` maps 1:1 to `UITabBarItem.badgeValue` (takes precedence over `badgeCount`), `badgeColor` to the badge background, and `badgeTextColor` to the glyph color. Combine `badgeText: "●"` + a transparent `badgeColor` + a `badgeTextColor` to render a clean dot indicator (Threads/Instagram style) instead of a numeric pill.
+
 ## [0.1.108]
 * **IMPROVEMENT**: Migrated the iOS plugin from CocoaPods to Swift Package Manager — apps with SPM enabled (`flutter config --enable-swift-package-manager`) now consume the plugin as a Swift package, while CocoaPods-based projects keep working unchanged (@philipgiuliani)
 * **IMPROVEMENT**: Raised the iOS minimum deployment target from 12.0 to 13.0, matching Flutter's supported minimum (@philipgiuliani)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,10 +28,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -152,26 +152,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -229,10 +229,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:

--- a/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26TabBarPlatformView.swift
+++ b/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26TabBarPlatformView.swift
@@ -34,7 +34,41 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
     private var currentSelectedNetworkIcons: [String] = []
     private var currentSearchFlags: [Bool] = []
     private var currentBadgeCounts: [Int?] = []
+    private var currentBadgeTexts: [String?] = []
+    private var currentBadgeColors: [Int?] = []
+    private var currentBadgeTextColors: [Int?] = []
     private let imageCache = NSCache<NSString, UIImage>()
+
+    /// Applies a badge to a tab bar item from the Flutter-provided styling.
+    /// Precedence: a non-empty [text] wins over [count]; otherwise a positive
+    /// [count] is shown; otherwise no badge. [colorARGB] sets the badge
+    /// background (nil = system default red), [textColorARGB] the glyph color
+    /// (nil = platform default). A transparent background + a colored glyph
+    /// renders a clean dot (e.g. badgeText "●").
+    private static func applyBadge(to item: UITabBarItem, count: Int?, text: String?, colorARGB: Int?, textColorARGB: Int?) {
+        let value: String?
+        if let text = text, !text.isEmpty {
+            value = text
+        } else if let count = count, count > 0 {
+            value = count > 99 ? "99+" : String(count)
+        } else {
+            value = nil
+        }
+        item.badgeValue = value
+        item.badgeColor = colorARGB != nil ? colorFromARGB(colorARGB!) : nil
+        if let argb = textColorARGB {
+            let attrs: [NSAttributedString.Key: Any] = [.foregroundColor: colorFromARGB(argb)]
+            item.setBadgeTextAttributes(attrs, for: .normal)
+            item.setBadgeTextAttributes(attrs, for: .selected)
+        } else {
+            item.setBadgeTextAttributes(nil, for: .normal)
+            item.setBadgeTextAttributes(nil, for: .selected)
+        }
+    }
+
+    private static func badgeAt<T>(_ arr: [T?], _ i: Int) -> T? {
+        return i < arr.count ? arr[i] : nil
+    }
 
     init(frame: CGRect, viewId: Int64, args: Any?, messenger: FlutterBinaryMessenger) {
         self.channel = FlutterMethodChannel(
@@ -53,6 +87,9 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
         var selectedNetworkIcons: [String] = []
         var searchFlags: [Bool] = []
         var badgeCounts: [Int?] = []
+        var badgeTexts: [String?] = []
+        var badgeColors: [Int?] = []
+        var badgeTextColors: [Int?] = []
         var spacerFlags: [Bool] = []
         var selectedIndex: Int = 0
         var isDark: Bool = false
@@ -77,6 +114,15 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
             spacerFlags = (dict["spacerFlags"] as? [Bool]) ?? []
             if let badgeData = dict["badgeCounts"] as? [NSNumber?] {
                 badgeCounts = badgeData.map { $0?.intValue }
+            }
+            if let arr = dict["badgeTexts"] as? [Any?] {
+                badgeTexts = arr.map { $0 as? String }
+            }
+            if let arr = dict["badgeColors"] as? [NSNumber?] {
+                badgeColors = arr.map { $0?.intValue }
+            }
+            if let arr = dict["badgeTextColors"] as? [NSNumber?] {
+                badgeTextColors = arr.map { $0?.intValue }
             }
             if let v = dict["selectedIndex"] as? NSNumber { selectedIndex = v.intValue }
             if let v = dict["isDark"] as? NSNumber { isDark = v.boolValue }
@@ -257,12 +303,14 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                     }
                 }
 
-                // Set badge value if provided
-                if let count = badgeCount, count > 0 {
-                    item.badgeValue = count > 99 ? "99+" : String(count)
-                } else {
-                    item.badgeValue = nil
-                }
+                // Set badge (count / text / colors)
+                Self.applyBadge(
+                    to: item,
+                    count: badgeCount,
+                    text: Self.badgeAt(badgeTexts, i),
+                    colorARGB: Self.badgeAt(badgeColors, i),
+                    textColorARGB: Self.badgeAt(badgeTextColors, i)
+                )
 
                 items.append(item)
             }
@@ -303,6 +351,9 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
         self.currentSelectedNetworkIcons = selectedNetworkIcons
         self.currentSearchFlags = searchFlags
         self.currentBadgeCounts = badgeCounts
+        self.currentBadgeTexts = badgeTexts
+        self.currentBadgeColors = badgeColors
+        self.currentBadgeTextColors = badgeTextColors
         // Apply minimize behavior if available
         self.applyMinimizeBehavior()
 
@@ -374,7 +425,10 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
             if let badgeData = args["badgeCounts"] as? [NSNumber?] {
                 badgeCounts = badgeData.map { $0?.intValue }
             }
-            
+            let badgeTexts: [String?] = (args["badgeTexts"] as? [Any?])?.map { $0 as? String } ?? []
+            let badgeColors: [Int?] = (args["badgeColors"] as? [NSNumber?])?.map { $0?.intValue } ?? []
+            let badgeTextColors: [Int?] = (args["badgeTextColors"] as? [NSNumber?])?.map { $0?.intValue } ?? []
+
             self.currentLabels = labels
             self.currentSymbols = symbols
             self.currentAssetIcons = assetIcons
@@ -385,6 +439,9 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
             self.currentSelectedNetworkIcons = selectedNetworkIcons
             self.currentSearchFlags = searchFlags
             self.currentBadgeCounts = badgeCounts
+            self.currentBadgeTexts = badgeTexts
+            self.currentBadgeColors = badgeColors
+            self.currentBadgeTextColors = badgeTextColors
 
             let count = max(
                 max(labels.count, symbols.count),
@@ -478,12 +535,14 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                         }
                     }
 
-                    // Set badge value if provided
-                    if let count = badgeCount, count > 0 {
-                        item.badgeValue = count > 99 ? "99+" : String(count)
-                    } else {
-                        item.badgeValue = nil
-                    }
+                    // Set badge (count / text / colors)
+                    Self.applyBadge(
+                        to: item,
+                        count: badgeCount,
+                        text: Self.badgeAt(badgeTexts, i),
+                        colorARGB: Self.badgeAt(badgeColors, i),
+                        textColorARGB: Self.badgeAt(badgeTextColors, i)
+                    )
 
                     items.append(item)
                 }
@@ -599,18 +658,20 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
 
             let badgeCounts = badgeData.map { $0?.intValue }
             self.currentBadgeCounts = badgeCounts
+            self.currentBadgeTexts = (args["badgeTexts"] as? [Any?])?.map { $0 as? String } ?? []
+            self.currentBadgeColors = (args["badgeColors"] as? [NSNumber?])?.map { $0?.intValue } ?? []
+            self.currentBadgeTextColors = (args["badgeTextColors"] as? [NSNumber?])?.map { $0?.intValue } ?? []
 
             // Update existing tab bar items with new badge values
             if let bar = self.tabBar, let items = bar.items {
                 for (index, item) in items.enumerated() {
-                    if index < badgeCounts.count {
-                        let count = badgeCounts[index]
-                        if let count = count, count > 0 {
-                            item.badgeValue = count > 99 ? "99+" : String(count)
-                        } else {
-                            item.badgeValue = nil
-                        }
-                    }
+                    Self.applyBadge(
+                        to: item,
+                        count: Self.badgeAt(badgeCounts, index),
+                        text: Self.badgeAt(self.currentBadgeTexts, index),
+                        colorARGB: Self.badgeAt(self.currentBadgeColors, index),
+                        textColorARGB: Self.badgeAt(self.currentBadgeTextColors, index)
+                    )
                 }
             }
             result(nil)
@@ -715,9 +776,13 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                 }
             }
 
-            if let count = badgeCount, count > 0 {
-                item.badgeValue = count > 99 ? "99+" : String(count)
-            }
+            Self.applyBadge(
+                to: item,
+                count: badgeCount,
+                text: Self.badgeAt(currentBadgeTexts, i),
+                colorARGB: Self.badgeAt(currentBadgeColors, i),
+                textColorARGB: Self.badgeAt(currentBadgeTextColors, i)
+            )
 
             items.append(item)
         }

--- a/lib/src/widgets/adaptive_scaffold.dart
+++ b/lib/src/widgets/adaptive_scaffold.dart
@@ -17,6 +17,9 @@ class AdaptiveNavigationDestination {
     this.selectedIcon,
     this.isSearch = false,
     this.badgeCount,
+    this.badgeText,
+    this.badgeColor,
+    this.badgeTextColor,
     this.addSpacerAfter = false,
   });
 
@@ -43,6 +46,25 @@ class AdaptiveNavigationDestination {
   /// On iOS 26+: Uses native UITabBarItem.badgeValue
   /// On iOS <26 and Android: Uses AdaptiveBadge widget
   final int? badgeCount;
+
+  /// Arbitrary badge text — maps 1:1 to `UITabBarItem.badgeValue` on iOS 26+.
+  /// Use it for "NEW", "!", a glyph, etc. Takes precedence over [badgeCount]
+  /// when non-null.
+  ///
+  /// Tip: combine `badgeText: "●"` + [badgeColor] `Colors.transparent` +
+  /// [badgeTextColor] to render a clean dot indicator (no pill background),
+  /// Threads/Instagram style.
+  final String? badgeText;
+
+  /// Badge background color — maps to `UITabBarItem.badgeColor` on iOS 26+.
+  /// Defaults to the platform's default badge color (system red) when null.
+  /// Set to a transparent color to remove the pill background (e.g. for a dot).
+  final Color? badgeColor;
+
+  /// Badge text/glyph color — maps to the badge text attributes' foreground
+  /// color on iOS 26+. Defaults to the platform default (white) when null.
+  /// Pair with a transparent [badgeColor] to color a dot glyph.
+  final Color? badgeTextColor;
 
   /// Add flexible space after this tab item (iOS 26+ only)
   /// Useful for creating grouped tabs (e.g., left group and right group)

--- a/lib/src/widgets/ios26/ios26_native_tab_bar.dart
+++ b/lib/src/widgets/ios26/ios26_native_tab_bar.dart
@@ -61,6 +61,9 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
   List<String>? _lastNetworkIcons;
   List<String>? _lastSelectedNetworkIcons;
   List<int?>? _lastBadgeCounts;
+  List<String?>? _lastBadgeTexts;
+  List<int?>? _lastBadgeColors;
+  List<int?>? _lastBadgeTextColors;
   TabBarMinimizeBehavior? _lastMinimizeBehavior;
   bool? _lastHidden;
 
@@ -166,6 +169,19 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
       .map((e) => _extractNetworkUrl(e.selectedIcon ?? e.icon))
       .toList();
 
+  // ROA-267 / native badge styling: badge content + colors mapped to the
+  // native side (UITabBarItem.badgeValue / .badgeColor / badge text attrs).
+  List<String?> _mapBadgeTexts() =>
+      widget.destinations.map((e) => e.badgeText).toList();
+
+  List<int?> _mapBadgeColors() => widget.destinations
+      .map((e) => e.badgeColor != null ? _colorToARGB(e.badgeColor!) : null)
+      .toList();
+
+  List<int?> _mapBadgeTextColors() => widget.destinations
+      .map((e) => e.badgeTextColor != null ? _colorToARGB(e.badgeTextColor!) : null)
+      .toList();
+
   @override
   Widget build(BuildContext context) {
     if (!kIsWeb && Platform.isIOS) {
@@ -180,6 +196,9 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
 
       final searchFlags = widget.destinations.map((e) => e.isSearch).toList();
       final badgeCounts = widget.destinations.map((e) => e.badgeCount).toList();
+      final badgeTexts = _mapBadgeTexts();
+      final badgeColors = _mapBadgeColors();
+      final badgeTextColors = _mapBadgeTextColors();
       final spacerFlags = widget.destinations
           .map((e) => e.addSpacerAfter)
           .toList();
@@ -195,6 +214,9 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
         'selectedNetworkIcons': selectedNetworkIcons,
         'searchFlags': searchFlags,
         'badgeCounts': badgeCounts,
+        'badgeTexts': badgeTexts,
+        'badgeColors': badgeColors,
+        'badgeTextColors': badgeTextColors,
         'spacerFlags': spacerFlags,
         'selectedIndex': widget.selectedIndex,
         'isDark': _isDark,
@@ -366,6 +388,9 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
         'selectedNetworkIcons': selectedNetworkIcons,
         'searchFlags': searchFlags,
         'badgeCounts': badgeCounts,
+        'badgeTexts': _mapBadgeTexts(),
+        'badgeColors': _mapBadgeColors(),
+        'badgeTextColors': _mapBadgeTextColors(),
         'selectedIndex': widget.selectedIndex,
       });
       _lastLabels = labels;
@@ -379,15 +404,27 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
       _requestIntrinsicSize();
     }
 
-    // Badge counts update
+    // Badge update (count + text + colors). Re-push when any badge input changes.
     final currentBadgeCounts = widget.destinations
         .map((e) => e.badgeCount)
         .toList();
-    if (_lastBadgeCounts?.join('|') != currentBadgeCounts.join('|')) {
+    final currentBadgeTexts = _mapBadgeTexts();
+    final currentBadgeColors = _mapBadgeColors();
+    final currentBadgeTextColors = _mapBadgeTextColors();
+    if (_lastBadgeCounts?.join('|') != currentBadgeCounts.join('|') ||
+        _lastBadgeTexts?.join('|') != currentBadgeTexts.join('|') ||
+        _lastBadgeColors?.join('|') != currentBadgeColors.join('|') ||
+        _lastBadgeTextColors?.join('|') != currentBadgeTextColors.join('|')) {
       await ch.invokeMethod('setBadgeCounts', {
         'badgeCounts': currentBadgeCounts,
+        'badgeTexts': currentBadgeTexts,
+        'badgeColors': currentBadgeColors,
+        'badgeTextColors': currentBadgeTextColors,
       });
       _lastBadgeCounts = currentBadgeCounts;
+      _lastBadgeTexts = currentBadgeTexts;
+      _lastBadgeColors = currentBadgeColors;
+      _lastBadgeTextColors = currentBadgeTextColors;
     }
 
     // Minimize behavior update
@@ -432,6 +469,9 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
     _lastNetworkIcons = _mapNetworkIcons();
     _lastSelectedNetworkIcons = _mapSelectedNetworkIcons();
     _lastBadgeCounts = widget.destinations.map((e) => e.badgeCount).toList();
+    _lastBadgeTexts = _mapBadgeTexts();
+    _lastBadgeColors = _mapBadgeColors();
+    _lastBadgeTextColors = _mapBadgeTextColors();
   }
 
   Future<void> _syncHiddenIfNeeded() async {
@@ -481,6 +521,9 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
         'selectedNetworkIcons': selectedNetworkIcons,
         'searchFlags': searchFlags,
         'badgeCounts': badgeCounts,
+        'badgeTexts': _mapBadgeTexts(),
+        'badgeColors': _mapBadgeColors(),
+        'badgeTextColors': _mapBadgeTextColors(),
         'selectedIndex': widget.selectedIndex,
       });
 


### PR DESCRIPTION
## What

Adds three fields to `AdaptiveNavigationDestination` for full control over the iOS 26+ native tab bar badge:

- **`badgeText: String?`** — maps 1:1 to `UITabBarItem.badgeValue`. Use for `"NEW"`, `"!"`, a glyph, etc. Takes precedence over `badgeCount` when non-null.
- **`badgeColor: Color?`** — maps to `UITabBarItem.badgeColor` (background). A transparent color removes the pill.
- **`badgeTextColor: Color?`** — maps to the badge text attributes' foreground (glyph) color.

## Why

Today `badgeCount` only renders a numeric red pill. Apps frequently want a **clean dot indicator** ("new content" signal, Threads/Instagram style) rather than a number. UIKit has no dedicated dot badge, but the standard technique is a transparent badge background + a colored glyph. Exposing these native knobs lets callers compose it:

```dart
AdaptiveNavigationDestination(
  icon: 'square.grid.2x2',
  label: 'Hub',
  badgeText: hasNew ? '●' : null,
  badgeColor: Colors.transparent, // no pill
  badgeTextColor: Colors.red,     // red dot
)
```

It also enables arbitrary string/colored badges generally, not just dots.

## Implementation

- **Dart** (`adaptive_scaffold.dart`, `ios26/ios26_native_tab_bar.dart`): new fields + plumbed through `creationParams`, both `setItems` calls, and the `setBadgeCounts` diff (now re-pushes when text/colors change too).
- **Swift** (`iOS26TabBarPlatformView.swift`): parse `badgeTexts`/`badgeColors`/`badgeTextColors`; a shared `applyBadge(...)` helper applied at all four badge sites. Precedence: non-empty `badgeText` > positive `badgeCount` > none.
- **Backward compatible**: existing `badgeCount` behavior is unchanged when the new fields are unset.

## Notes

- Scoped to the iOS 26 platform-view tab bar path (`AdaptiveBottomNavigationBar`). The app-level `iOS26NativeTabBarManager` (search tab bar) path is untouched; happy to extend it in a follow-up if desired.
- A demo addition to `badge_navigation_demo_page.dart` can be added on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)