### PR TITLE
feat: per-state SF Symbols on iOS 26 native tab bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.110]
+* **NEW**: Per-state SF Symbols on the iOS 26+ native tab bar — `AdaptiveNavigationDestination.selectedIcon` now accepts a distinct SF Symbol name (e.g. `magazine.fill`) that is applied for the selected state, matching the existing per-state behavior for asset/file/network icons (@philipgiuliani)
+
 ## [0.1.109]
 * **NEW**: `triggerOnLongPress` and `onTap` on popup menu buttons — tap fires `onTap`, long-press opens the menu (@yuriylybimov)
 * **NEW**: `isDestructive` on `AdaptivePopupMenuItem` — renders destructive (red) styling on Material, iOS <26, and iOS 26+ native menus (@yuriylybimov)

--- a/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26TabBarPlatformView.swift
+++ b/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26TabBarPlatformView.swift
@@ -26,6 +26,7 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
     private var minimizeBehavior: Int = 3 // automatic
     private var currentLabels: [String] = []
     private var currentSymbols: [String] = []
+    private var currentSelectedSymbols: [String] = []
     private var currentAssetIcons: [String] = []
     private var currentSelectedAssetIcons: [String] = []
     private var currentFileIcons: [String] = []
@@ -45,6 +46,7 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
 
         var labels: [String] = []
         var symbols: [String] = []
+        var selectedSymbols: [String] = []
         var assetIcons: [String] = []
         var selectedAssetIcons: [String] = []
         var fileIcons: [String] = []
@@ -67,6 +69,7 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
             NSLog("📦 TabBar init dict keys: \(dict.keys)")
             labels = (dict["labels"] as? [String]) ?? []
             symbols = (dict["sfSymbols"] as? [String]) ?? []
+            selectedSymbols = (dict["selectedSfSymbols"] as? [String]) ?? []
             assetIcons = (dict["assetIcons"] as? [String]) ?? []
             selectedAssetIcons = (dict["selectedAssetIcons"] as? [String]) ?? []
             fileIcons = (dict["fileIcons"] as? [String]) ?? []
@@ -230,6 +233,10 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                                 selectedImage = selRawImage
                             }
                         } else if i < symbols.count && !symbols[i].isEmpty {
+                            // Selected state may use a distinct SF Symbol (e.g. filled variant).
+                            let selSymbol = (i < selectedSymbols.count && !selectedSymbols[i].isEmpty)
+                                ? selectedSymbols[i]
+                                : symbols[i]
                             // iOS 26+: Use different rendering modes for selected/unselected
                             if #available(iOS 26.0, *) {
                                 // Unselected: Only apply custom color if unselectedTint is provided
@@ -244,11 +251,11 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                                 }
 
                                 // Selected: Use template rendering so tintColor applies
-                                selectedImage = UIImage(systemName: symbols[i])?.withRenderingMode(.alwaysTemplate)
+                                selectedImage = UIImage(systemName: selSymbol)?.withRenderingMode(.alwaysTemplate)
                             } else {
                                 // iOS <26: Use default behavior
                                 image = UIImage(systemName: symbols[i])
-                                selectedImage = image
+                                selectedImage = UIImage(systemName: selSymbol)
                             }
                         }
 
@@ -362,6 +369,7 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                 return
             }
 
+            let selectedSymbols = (args["selectedSfSymbols"] as? [String]) ?? []
             let assetIcons = (args["assetIcons"] as? [String]) ?? []
             let selectedAssetIcons = (args["selectedAssetIcons"] as? [String]) ?? []
             let fileIcons = (args["fileIcons"] as? [String]) ?? []
@@ -377,6 +385,7 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
             
             self.currentLabels = labels
             self.currentSymbols = symbols
+            self.currentSelectedSymbols = selectedSymbols
             self.currentAssetIcons = assetIcons
             self.currentSelectedAssetIcons = selectedAssetIcons
             self.currentFileIcons = fileIcons
@@ -449,6 +458,10 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                                     selectedImage = selRawImage
                                 }
                             } else if i < symbols.count && !symbols[i].isEmpty {
+                                // Selected state may use a distinct SF Symbol (e.g. filled variant).
+                                let selSymbol = (i < selectedSymbols.count && !selectedSymbols[i].isEmpty)
+                                    ? selectedSymbols[i]
+                                    : symbols[i]
                                 // iOS 26+: Use different rendering modes for selected/unselected
                                 if #available(iOS 26.0, *) {
                                     // Get current unselected color from tab bar
@@ -465,11 +478,11 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                                     }
 
                                     // Selected: Use template rendering so tintColor applies
-                                    selectedImage = UIImage(systemName: symbols[i])?.withRenderingMode(.alwaysTemplate)
+                                    selectedImage = UIImage(systemName: selSymbol)?.withRenderingMode(.alwaysTemplate)
                                 } else {
                                     // iOS <26: Use default behavior
                                     image = UIImage(systemName: symbols[i])
-                                    selectedImage = image
+                                    selectedImage = UIImage(systemName: selSymbol)
                                 }
                             }
 
@@ -693,6 +706,10 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                             }
                         }
                     } else if i < currentSymbols.count && !currentSymbols[i].isEmpty {
+                        // Selected state may use a distinct SF Symbol (e.g. filled variant).
+                        let selSymbol = (i < currentSelectedSymbols.count && !currentSelectedSymbols[i].isEmpty)
+                            ? currentSelectedSymbols[i]
+                            : currentSymbols[i]
                         if #available(iOS 26.0, *) {
                             let unselTint = bar.unselectedItemTintColor
 
@@ -703,10 +720,10 @@ class iOS26TabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelegate {
                             } else {
                                 image = UIImage(systemName: currentSymbols[i])?.withRenderingMode(.alwaysTemplate)
                             }
-                            selectedImage = UIImage(systemName: currentSymbols[i])?.withRenderingMode(.alwaysTemplate)
+                            selectedImage = UIImage(systemName: selSymbol)?.withRenderingMode(.alwaysTemplate)
                         } else {
                             image = UIImage(systemName: currentSymbols[i])
-                            selectedImage = image
+                            selectedImage = UIImage(systemName: selSymbol)
                         }
                     }
 

--- a/lib/src/widgets/adaptive_scaffold.dart
+++ b/lib/src/widgets/adaptive_scaffold.dart
@@ -32,7 +32,11 @@ class AdaptiveNavigationDestination {
   /// Label text for the destination
   final String label;
 
-  /// Optional selected state icon
+  /// Optional selected state icon.
+  ///
+  /// Accepts the same value types as [icon], including an SF Symbol name
+  /// `String` (e.g. `magazine.fill`) which the iOS 26+ native tab bar applies
+  /// when the destination is selected. Falls back to [icon] when null.
   final dynamic selectedIcon;
 
   /// Whether this is a search tab (iOS 26+)

--- a/lib/src/widgets/ios26/ios26_native_tab_bar.dart
+++ b/lib/src/widgets/ios26/ios26_native_tab_bar.dart
@@ -54,6 +54,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
   double? _intrinsicHeight;
   List<String>? _lastLabels;
   List<String>? _lastSymbols;
+  List<String>? _lastSelectedSymbols;
   List<String>? _lastAssetIcons;
   List<String>? _lastSelectedAssetIcons;
   List<String>? _lastFileIcons;
@@ -145,6 +146,10 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
   List<String> _mapSymbols() =>
       widget.destinations.map((e) => _extractSymbol(e.icon)).toList();
 
+  List<String> _mapSelectedSymbols() => widget.destinations
+      .map((e) => _extractSymbol(e.selectedIcon ?? e.icon))
+      .toList();
+
   List<String> _mapAssetIcons() =>
       widget.destinations.map((e) => _extractAssetPath(e.icon)).toList();
 
@@ -171,6 +176,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
     if (!kIsWeb && Platform.isIOS) {
       final labels = widget.destinations.map((e) => e.label).toList();
       final symbols = _mapSymbols();
+      final selectedSymbols = _mapSelectedSymbols();
       final assetIcons = _mapAssetIcons();
       final selectedAssetIcons = _mapSelectedAssetIcons();
       final fileIcons = _mapFileIcons();
@@ -187,6 +193,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
       final creationParams = <String, dynamic>{
         'labels': labels,
         'sfSymbols': symbols,
+        'selectedSfSymbols': selectedSymbols,
         'assetIcons': assetIcons,
         'selectedAssetIcons': selectedAssetIcons,
         'fileIcons': fileIcons,
@@ -337,6 +344,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
     // Items update (for hot reload or dynamic changes)
     final labels = widget.destinations.map((e) => e.label).toList();
     final symbols = _mapSymbols();
+    final selectedSymbols = _mapSelectedSymbols();
     final assetIcons = _mapAssetIcons();
     final selectedAssetIcons = _mapSelectedAssetIcons();
     final fileIcons = _mapFileIcons();
@@ -348,6 +356,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
 
     if (_lastLabels?.join('|') != labels.join('|') ||
         _lastSymbols?.join('|') != symbols.join('|') ||
+        _lastSelectedSymbols?.join('|') != selectedSymbols.join('|') ||
         _lastAssetIcons?.join('|') != assetIcons.join('|') ||
         _lastSelectedAssetIcons?.join('|') != selectedAssetIcons.join('|') ||
         _lastFileIcons?.join('|') != fileIcons.join('|') ||
@@ -358,6 +367,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
       await ch.invokeMethod('setItems', {
         'labels': labels,
         'sfSymbols': symbols,
+        'selectedSfSymbols': selectedSymbols,
         'assetIcons': assetIcons,
         'selectedAssetIcons': selectedAssetIcons,
         'fileIcons': fileIcons,
@@ -370,6 +380,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
       });
       _lastLabels = labels;
       _lastSymbols = symbols;
+      _lastSelectedSymbols = selectedSymbols;
       _lastAssetIcons = assetIcons;
       _lastSelectedAssetIcons = selectedAssetIcons;
       _lastFileIcons = fileIcons;
@@ -425,6 +436,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
   void _cacheItems() {
     _lastLabels = widget.destinations.map((e) => e.label).toList();
     _lastSymbols = _mapSymbols();
+    _lastSelectedSymbols = _mapSelectedSymbols();
     _lastAssetIcons = _mapAssetIcons();
     _lastSelectedAssetIcons = _mapSelectedAssetIcons();
     _lastFileIcons = _mapFileIcons();
@@ -460,6 +472,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
   Future<void> _pushInitialStateToNative(MethodChannel ch) async {
     final labels = widget.destinations.map((e) => e.label).toList();
     final symbols = _mapSymbols();
+    final selectedSymbols = _mapSelectedSymbols();
     final assetIcons = _mapAssetIcons();
     final selectedAssetIcons = _mapSelectedAssetIcons();
     final fileIcons = _mapFileIcons();
@@ -473,6 +486,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
       await ch.invokeMethod('setItems', {
         'labels': labels,
         'sfSymbols': symbols,
+        'selectedSfSymbols': selectedSymbols,
         'assetIcons': assetIcons,
         'selectedAssetIcons': selectedAssetIcons,
         'fileIcons': fileIcons,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adaptive_platform_ui
 description: "Adaptive platform-specific widgets for Flutter. Auto renders native iOS 26+ liquid glass designs, traditional Cupertino widgets for older iOS versions, Material Design for Android."
-version: 0.1.109
+version: 0.1.110
 homepage: https://github.com/berkaycatak/adaptive_platform_ui
 screenshots:
   - description: "iOS 26+ liquid glass designs"


### PR DESCRIPTION
On the iOS 26 native tab bar, SF Symbols only forwarded `icon` and reused it for both states, so `selectedIcon` was ignored and a filled-on-select variant wasn't possible. Asset, file and network icons already have a selected variant, this adds the same for SF Symbols.

`selectedSfSymbols` is forwarded from Dart (falling back to `icon`) and used for `item.selectedImage` in the three native item builders. No behavior change when `selectedIcon` is unset.

Tested on device (iOS 26): outline when unselected, `.fill` when selected.
