### PR TITLE
fix(ios26): fix modal canvas clipping and alert dialog navigation lay…

### DIFF
--- a/lib/src/widgets/adaptive_alert_dialog.dart
+++ b/lib/src/widgets/adaptive_alert_dialog.dart
@@ -71,7 +71,8 @@ class AdaptiveAlertDialog {
 
       return showCupertinoDialog<void>(
         context: context,
-        barrierColor: CupertinoColors.transparent,
+        useRootNavigator: true,
+        barrierColor: Colors.black.withValues(alpha: 0.35),
         builder: (context) => IOS26AlertDialog(
           title: title,
           message: message,
@@ -219,6 +220,8 @@ class AdaptiveAlertDialog {
 
       return showCupertinoDialog<String?>(
         context: context,
+        useRootNavigator: true,
+        barrierColor: Colors.black.withValues(alpha: 0.35),
         builder: (context) => IOS26AlertDialog(
           title: title,
           message: message,

--- a/lib/src/widgets/ios26/ios26_native_tab_bar.dart
+++ b/lib/src/widgets/ios26/ios26_native_tab_bar.dart
@@ -207,7 +207,7 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
           'backgroundColor': _colorToARGB(widget.backgroundColor!),
       };
 
-      final platformView = widget.showNativeView
+      final platformView = widget.showNativeView && !widget.hidden
           ? UiKitView(
               viewType: 'adaptive_platform_ui/ios26_tab_bar',
               creationParams: creationParams,
@@ -500,6 +500,8 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
 
       await ch.invokeMethod('setSelectedIndex', {'index': widget.selectedIndex});
       _lastIndex = widget.selectedIndex;
+      await ch.invokeMethod('setHidden', {'hidden': widget.hidden});
+      _lastHidden = widget.hidden;
       await _requestIntrinsicSize();
     } catch (_) {}
   }

--- a/lib/src/widgets/ios26/ios26_scaffold.dart
+++ b/lib/src/widgets/ios26/ios26_scaffold.dart
@@ -181,8 +181,8 @@ class _IOS26ScaffoldState extends State<IOS26Scaffold>
         heroLeading != null ||
         (widget.actions != null && widget.actions!.isNotEmpty));
 
-    // Show native view only if it's the current route OR it's popping
-    final showNativeView = isCurrentRoute || isPopping;
+    // Show native view only if it's the current route OR it's popping, AND the tab bar is not explicitly hidden
+    final showNativeView = (isCurrentRoute || isPopping) && !widget.tabBarHidden;
 
     // Get brightness and determine text color
     final brightness = MediaQuery.platformBrightnessOf(context);


### PR DESCRIPTION
# fix(ios26): Resolve modal clipping, bleed-through, and dialog overlays over native tab bars

## Description
This PR addresses iOS 26+ hybrid composition layout issues. When displaying overlays (e.g. modal routes, bottom sheets, or alert dialogs) over an active `AdaptiveScaffold`, the native bottom tab bar (`IOS26NativeTabBar` / `UITabBar`) remains mounted as a `UiKitView` even when `tabBarHidden` is `true`. 

Flutter's Hybrid Composition on iOS splits the Metal rendering canvas for the platform view, causing any overlay route positioned on top of it to be severely clipped and hidden (only rendering components matching the tab bar height, leaving the rest of the sheet invisible).

Additionally, this PR fixes:
1. `IOS26NativeTabBar` not synchronizing its initial `hidden` state to the native Swift side inside `_pushInitialStateToNative`.
2. `AdaptiveAlertDialog` on iOS 26+ being pushed on the local nested navigator instead of the root navigator, which lets the native tab bar bleed through and remain fully interactive on top of the alert dialog, and the background scrim not dimming correctly.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement

## Related Issues
Closes #

## Changes Made
- **Scaffold Platform View Unmounting**: Modified `IOS26Scaffold`'s `showNativeView` evaluation to check for `!widget.tabBarHidden`, and conditioned `IOS26NativeTabBar`'s `UiKitView` instantiation on `widget.showNativeView && !widget.hidden`. The native tab bar platform view is now completely unmounted (`SizedBox.shrink()`) from the Flutter widget tree when `hidden: true`, dissolving the canvas partitioning layers and preventing clipping.
- **Initial Native State Synchronization**: Added the `setHidden` method invocation inside `_pushInitialStateToNative` of `IOS26NativeTabBar` to immediately initialize the native container's visibility upon creation.
- **AdaptiveAlertDialog Root Navigation**: Set `useRootNavigator: true` and configured a translucent dark `barrierColor` on `showCupertinoDialog` inside `AdaptiveAlertDialog` to ensure alert overlays are rendered correctly above nested navigators and the native bottom bar.

## Testing

### Automated Tests ⚠️ **REQUIRED**
- [ ] I have added unit/widget tests for my changes
- [x] All new and existing tests pass locally (`flutter test`)
- [x] Code analysis passes with no errors (`flutter analyze`)
- [ ] Code formatting is correct (`dart format`)
- [ ] Test coverage is adequate (>80% for new code)

### Manual Testing
- [x] iOS 26+ tested
- [x] iOS <26 tested
- [x] Android tested
- [ ] Web tested (if applicable)
- [x] Tested in both light and dark mode
- [x] Tested with different screen sizes
- [ ] Tested with accessibility features (large fonts, screen readers, etc.)

## Screenshots/Videos

### Before
- Bottom sheets or modal routes pushed above a scaffold with a native bottom tab bar are clipped at the tab bar height, making the rest of the overlay content invisible.
- Alert dialogs allow the native tab bar to bleed through and remain interactable.

### After
- Overlays render completely and natively above the entire scaffold context.
- Alert dialogs overlay the tab bar correctly, dimming the background canvas uniformly.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] My changes generate no new warnings
- [ ] I have checked that my code does not introduce any accessibility issues
- [ ] I have updated the CHANGELOG.md file (if applicable)
- [ ] I have updated version number in pubspec.yaml (if applicable)
- [ ] I have added examples to the example app (if adding new widgets)

## Breaking Changes
None. The modifications are fully backwards-compatible and preserve the existing public API surface.

## Additional Notes
Tested locally with the library unit test suite comprising 221 tests (all passing).
