### PR TITLE
feat: app bar subtitle and custom titleWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## [Unreleased]
-* **NEW**: `subtitle` and `titleWidget` on `AdaptiveAppBar` — show a smaller subtitle below the title, or replace the title area with any widget. Works on iOS 26+ native toolbar (as a centered overlay), iOS <26 `CupertinoNavigationBar`, and Material `AppBar` (@luflow)
-
 ## [0.1.109]
 * **NEW**: `triggerOnLongPress` and `onTap` on popup menu buttons — tap fires `onTap`, long-press opens the menu (@yuriylybimov)
 * **NEW**: `isDestructive` on `AdaptivePopupMenuItem` — renders destructive (red) styling on Material, iOS <26, and iOS 26+ native menus (@yuriylybimov)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+* **NEW**: `subtitle` and `titleWidget` on `AdaptiveAppBar` — show a smaller subtitle below the title, or replace the title area with any widget. Works on iOS 26+ native toolbar (as a centered overlay), iOS <26 `CupertinoNavigationBar`, and Material `AppBar` (@luflow)
+
 ## [0.1.109]
 * **NEW**: `triggerOnLongPress` and `onTap` on popup menu buttons — tap fires `onTap`, long-press opens the menu (@yuriylybimov)
 * **NEW**: `isDestructive` on `AdaptivePopupMenuItem` — renders destructive (red) styling on Material, iOS <26, and iOS 26+ native menus (@yuriylybimov)

--- a/example/lib/pages/demos/appbar_title_demo_page.dart
+++ b/example/lib/pages/demos/appbar_title_demo_page.dart
@@ -1,0 +1,95 @@
+import 'package:adaptive_platform_ui/adaptive_platform_ui.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class AppBarTitleDemoPage extends StatefulWidget {
+  const AppBarTitleDemoPage({super.key});
+
+  @override
+  State<AppBarTitleDemoPage> createState() => _AppBarTitleDemoPageState();
+}
+
+enum _TitleMode { plain, subtitle, custom }
+
+class _AppBarTitleDemoPageState extends State<AppBarTitleDemoPage> {
+  _TitleMode _mode = _TitleMode.subtitle;
+
+  AdaptiveAppBar _buildAppBar() {
+    switch (_mode) {
+      case _TitleMode.plain:
+        return AdaptiveAppBar(title: 'App Bar Title');
+      case _TitleMode.subtitle:
+        return AdaptiveAppBar(
+          title: 'App Bar Title',
+          subtitle: '12 unread messages',
+        );
+      case _TitleMode.custom:
+        return AdaptiveAppBar(
+          title: 'App Bar Title',
+          titleWidget: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                PlatformInfo.isIOS
+                    ? CupertinoIcons.person_crop_circle_fill
+                    : Icons.account_circle,
+                size: 24,
+              ),
+              const SizedBox(width: 8),
+              const Text(
+                'Custom Widget',
+                style: TextStyle(fontSize: 17, fontWeight: FontWeight.w600),
+              ),
+            ],
+          ),
+        );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AdaptiveScaffold(
+      appBar: _buildAppBar(),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          const SizedBox(height: 110),
+          Text(
+            'Title Mode',
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: PlatformInfo.isIOS
+                  ? CupertinoColors.label
+                  : Theme.of(context).colorScheme.onSurface,
+            ),
+          ),
+          const SizedBox(height: 12),
+          AdaptiveSegmentedControl(
+            labels: const ['Plain', 'Subtitle', 'Custom'],
+            selectedIndex: _mode.index,
+            onValueChanged: (value) {
+              setState(() => _mode = _TitleMode.values[value]);
+            },
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'The app bar above updates live:\n\n'
+            '• Plain — a regular string title\n'
+            '• Subtitle — title with a smaller subtitle below it\n'
+            '• Custom — a titleWidget replacing the title area entirely\n\n'
+            'On iOS 26+ the subtitle/custom widget is overlaid centered on '
+            'the native Liquid Glass toolbar; on iOS <26 it becomes the '
+            'CupertinoNavigationBar middle; on Android it is the AppBar title.',
+            style: TextStyle(
+              fontSize: 15,
+              color: PlatformInfo.isIOS
+                  ? CupertinoColors.secondaryLabel
+                  : Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/pages/home/home_page.dart
+++ b/example/lib/pages/home/home_page.dart
@@ -353,6 +353,16 @@ class _HomePageState extends State<HomePage> {
               ),
               _DemoItem(
                 icon: PlatformInfo.isIOS
+                    ? CupertinoIcons.textformat
+                    : Icons.title,
+                title: 'App Bar Title',
+                description:
+                    'Subtitle and custom titleWidget in the app bar',
+                routeName: RouterService.routes.appBarTitle,
+                isNew: true,
+              ),
+              _DemoItem(
+                icon: PlatformInfo.isIOS
                     ? CupertinoIcons.search_circle_fill
                     : Icons.search,
                 title: 'Native Search Tab',

--- a/example/lib/service/router/router_service.dart
+++ b/example/lib/service/router/router_service.dart
@@ -12,6 +12,7 @@ import 'package:adaptive_platform_ui_example/pages/demos/context_menu_demo_page.
 import 'package:adaptive_platform_ui_example/pages/demos/demo_tabbar_page.dart';
 import 'package:adaptive_platform_ui_example/pages/demos/native_search_tab_demo_page.dart';
 import 'package:adaptive_platform_ui_example/pages/demos/popup_menu_demo_page.dart';
+import 'package:adaptive_platform_ui_example/pages/demos/appbar_title_demo_page.dart';
 import 'package:adaptive_platform_ui_example/pages/demos/radio_demo_page.dart';
 import 'package:adaptive_platform_ui_example/pages/demos/segmented_control_demo_page.dart';
 import 'package:adaptive_platform_ui_example/pages/demos/slider_demo_page.dart';
@@ -256,6 +257,12 @@ class RouterService {
                     path: routes.toolbarTint,
                     builder: (context, state) =>
                         const ToolbarTintDemoPage(),
+                  ),
+                  GoRoute(
+                    name: routes.appBarTitle,
+                    path: routes.appBarTitle,
+                    builder: (context, state) =>
+                        const AppBarTitleDemoPage(),
                   ),
                   GoRoute(
                     name: routes.navigationPage1,

--- a/example/lib/utils/constants/route_constants.dart
+++ b/example/lib/utils/constants/route_constants.dart
@@ -34,6 +34,7 @@ class RouteConstants {
   String blurView = 'blur-view';
   String drawer = 'drawer';
   String toolbarTint = 'toolbar-tint';
+  String appBarTitle = 'app-bar-title';
   String navigationPage1 = 'navigation-page1';
   String navigationPage2 = 'navigation-page2';
   String navigationPage3 = 'navigation-page3';

--- a/lib/src/widgets/adaptive_app_bar.dart
+++ b/lib/src/widgets/adaptive_app_bar.dart
@@ -18,16 +18,21 @@ class AdaptiveAppBar {
   /// Creates an adaptive app bar configuration
   const AdaptiveAppBar({
     this.title,
+    this.subtitle,
     this.actions,
     this.leading,
     this.useNativeToolbar = true,
     this.tintColor,
+    this.titleWidget,
     this.cupertinoNavigationBar,
     this.appBar,
   });
 
   /// Title for the app bar
   final String? title;
+
+  /// Optional subtitle displayed below the title
+  final String? subtitle;
 
   /// Action buttons in the app bar
   /// - iOS 26+ with native toolbar: Rendered as native UIBarButtonItem in UIToolbar
@@ -48,6 +53,14 @@ class AdaptiveAppBar {
   ///
   /// If true, [cupertinoNavigationBar] will be ignored and native toolbar will be shown.
   final bool useNativeToolbar;
+
+  /// Custom widget to display in the title area
+  ///
+  /// When set, this widget replaces the default title text rendering.
+  /// On iOS 26+ with native toolbar, it is overlaid centered over the toolbar.
+  /// On iOS < 26, it is used as the CupertinoNavigationBar middle.
+  /// On Android, it is used as the AppBar title.
+  final Widget? titleWidget;
 
   /// Tint color for toolbar action buttons (iOS 26+ native toolbar only)
   ///
@@ -75,19 +88,23 @@ class AdaptiveAppBar {
   /// Creates a copy of this app bar with the given fields replaced
   AdaptiveAppBar copyWith({
     String? title,
+    String? subtitle,
     List<AdaptiveAppBarAction>? actions,
     Widget? leading,
     bool? useNativeToolbar,
     Color? tintColor,
+    Widget? titleWidget,
     PreferredSizeWidget? cupertinoNavigationBar,
     PreferredSizeWidget? appBar,
   }) {
     return AdaptiveAppBar(
       title: title ?? this.title,
+      subtitle: subtitle ?? this.subtitle,
       actions: actions ?? this.actions,
       leading: leading ?? this.leading,
       useNativeToolbar: useNativeToolbar ?? this.useNativeToolbar,
       tintColor: tintColor ?? this.tintColor,
+      titleWidget: titleWidget ?? this.titleWidget,
       cupertinoNavigationBar:
           cupertinoNavigationBar ?? this.cupertinoNavigationBar,
       appBar: appBar ?? this.appBar,

--- a/lib/src/widgets/adaptive_scaffold.dart
+++ b/lib/src/widgets/adaptive_scaffold.dart
@@ -176,6 +176,76 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
   final GlobalKey<_MinimizableTabBarState> _tabBarKey =
       GlobalKey<_MinimizableTabBarState>();
 
+  /// Overlay for the iOS 26+ native toolbar title area. The native title is a
+  /// plain string, so a subtitle (or custom widget) is drawn as a Flutter
+  /// overlay instead; returns null when the native title can render natively.
+  Widget? _buildIOS26TitleOverlay() {
+    if (widget.appBar?.titleWidget != null) return widget.appBar!.titleWidget;
+    final subtitle = widget.appBar?.subtitle;
+    if (widget.appBar?.title == null || subtitle == null || subtitle.isEmpty) {
+      return null;
+    }
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          widget.appBar!.title!,
+          style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w600),
+        ),
+        Text(
+          subtitle,
+          style: const TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.normal,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget? _buildTitleWidget() {
+    if (widget.appBar?.titleWidget != null) return widget.appBar!.titleWidget;
+    if (widget.appBar?.title == null) return null;
+    final subtitle = widget.appBar?.subtitle;
+    if (subtitle == null || subtitle.isEmpty) return Text(widget.appBar!.title!);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(widget.appBar!.title!),
+        Text(
+          subtitle,
+          style: const TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.normal,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget? _buildMaterialTitleWidget() {
+    if (widget.appBar?.titleWidget != null) return widget.appBar!.titleWidget;
+    if (widget.appBar?.title == null) return null;
+    final subtitle = widget.appBar?.subtitle;
+    if (subtitle == null || subtitle.isEmpty) return Text(widget.appBar!.title!);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(widget.appBar!.title!),
+        Text(
+          subtitle,
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.normal,
+            color:
+                Theme.of(context).textTheme.bodySmall?.color?.withValues(alpha: 0.7),
+          ),
+        ),
+      ],
+    );
+  }
+
   Widget _wrapWithDrawerIfNeeded(Widget child) {
     if (widget.drawer == null && widget.endDrawer == null) {
       return child;
@@ -256,6 +326,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
           actions: widget.appBar?.actions,
           leading: widget.appBar?.leading,
           tintColor: widget.appBar?.tintColor,
+          titleWidget: _buildIOS26TitleOverlay(),
           minimizeBehavior: widget.minimizeBehavior,
           enableBlur: widget.enableBlur,
           useHeroBackButton: widget.useHeroBackButton,
@@ -298,9 +369,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
                 PlatformInfo.isIOS26OrHigher() && useNativeToolbar
                 ? false
                 : true, // Let CupertinoNavigationBar handle back button naturally
-            middle: widget.appBar!.title != null
-                ? Text(widget.appBar!.title!)
-                : null,
+            middle: _buildTitleWidget(),
             trailing:
                 widget.appBar!.actions != null &&
                     widget.appBar!.actions!.isNotEmpty
@@ -488,6 +557,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
       // Priority 2: Build from title, actions, leading (if appBar has content)
       else if (widget.appBar != null &&
           (widget.appBar!.title != null ||
+              widget.appBar!.titleWidget != null ||
               (widget.appBar!.actions != null &&
                   widget.appBar!.actions!.isNotEmpty) ||
               effectiveLeading != null ||
@@ -497,9 +567,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
               PlatformInfo.isIOS26OrHigher() && useNativeToolbar
               ? false
               : true, // Let CupertinoNavigationBar handle back button naturally
-          middle: widget.appBar!.title != null
-              ? Text(widget.appBar!.title!)
-              : null,
+          middle: _buildTitleWidget(),
           trailing:
               widget.appBar!.actions != null &&
                   widget.appBar!.actions!.isNotEmpty
@@ -578,13 +646,13 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
       // Priority 2: Build from title, actions, leading (if appBar has content)
       else if (widget.appBar != null &&
           (widget.appBar!.title != null ||
+              widget.appBar!.titleWidget != null ||
               (widget.appBar!.actions != null &&
                   widget.appBar!.actions!.isNotEmpty) ||
               widget.appBar!.leading != null)) {
         appBar = AppBar(
-          title: widget.appBar!.title != null
-              ? Text(widget.appBar!.title!)
-              : null,
+          title: _buildMaterialTitleWidget(),
+          centerTitle: widget.appBar!.titleWidget != null,
           actions: widget.appBar!.actions?.map((action) {
             if (action.title != null) {
               return TextButton(
@@ -677,9 +745,8 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
     // Priority 2: Build AppBar if widget.appBar is provided (even if empty - for automatic back button)
     else if (widget.appBar != null) {
       appBar = AppBar(
-        title: widget.appBar!.title != null
-            ? Text(widget.appBar!.title!)
-            : null,
+        title: _buildMaterialTitleWidget(),
+        centerTitle: widget.appBar!.titleWidget != null,
         actions: widget.appBar!.actions?.map((action) {
           if (action.title != null) {
             return TextButton(

--- a/lib/src/widgets/adaptive_scaffold.dart
+++ b/lib/src/widgets/adaptive_scaffold.dart
@@ -176,73 +176,56 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
   final GlobalKey<_MinimizableTabBarState> _tabBarKey =
       GlobalKey<_MinimizableTabBarState>();
 
-  /// Overlay for the iOS 26+ native toolbar title area. The native title is a
-  /// plain string, so a subtitle (or custom widget) is drawn as a Flutter
-  /// overlay instead; returns null when the native title can render natively.
-  Widget? _buildIOS26TitleOverlay() {
+  /// Builds the app bar title area, optionally with a subtitle below it.
+  ///
+  /// Returns [AdaptiveAppBar.titleWidget] verbatim when provided; otherwise a
+  /// title (plus subtitle when set). When [nativeTitleFallback] is true the
+  /// plain-title case returns null so the iOS 26 native toolbar can render the
+  /// title itself; the other paths return a plain `Text` instead.
+  Widget? _buildAppBarTitle({
+    CrossAxisAlignment crossAxisAlignment = CrossAxisAlignment.center,
+    TextStyle? titleStyle,
+    double subtitleFontSize = 12,
+    Color? subtitleColor,
+    bool nativeTitleFallback = false,
+  }) {
     if (widget.appBar?.titleWidget != null) return widget.appBar!.titleWidget;
+    final title = widget.appBar?.title;
+    if (title == null) return null;
     final subtitle = widget.appBar?.subtitle;
-    if (widget.appBar?.title == null || subtitle == null || subtitle.isEmpty) {
-      return null;
+    if (subtitle == null || subtitle.isEmpty) {
+      return nativeTitleFallback ? null : Text(title, style: titleStyle);
     }
     return Column(
       mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: crossAxisAlignment,
       children: [
-        Text(
-          widget.appBar!.title!,
-          style: const TextStyle(fontSize: 17, fontWeight: FontWeight.w600),
-        ),
-        Text(
-          subtitle,
-          style: const TextStyle(
-            fontSize: 12,
-            fontWeight: FontWeight.normal,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget? _buildTitleWidget() {
-    if (widget.appBar?.titleWidget != null) return widget.appBar!.titleWidget;
-    if (widget.appBar?.title == null) return null;
-    final subtitle = widget.appBar?.subtitle;
-    if (subtitle == null || subtitle.isEmpty) return Text(widget.appBar!.title!);
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(widget.appBar!.title!),
-        Text(
-          subtitle,
-          style: const TextStyle(
-            fontSize: 12,
-            fontWeight: FontWeight.normal,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget? _buildMaterialTitleWidget() {
-    if (widget.appBar?.titleWidget != null) return widget.appBar!.titleWidget;
-    if (widget.appBar?.title == null) return null;
-    final subtitle = widget.appBar?.subtitle;
-    if (subtitle == null || subtitle.isEmpty) return Text(widget.appBar!.title!);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(widget.appBar!.title!),
+        Text(title, style: titleStyle),
         Text(
           subtitle,
           style: TextStyle(
-            fontSize: 13,
+            fontSize: subtitleFontSize,
             fontWeight: FontWeight.normal,
-            color:
-                Theme.of(context).textTheme.bodySmall?.color?.withValues(alpha: 0.7),
+            color: subtitleColor,
           ),
         ),
       ],
+    );
+  }
+
+  /// iOS 26+ native toolbar title overlay. The native title is a plain string,
+  /// so a subtitle (or custom widget) is drawn as a Flutter overlay instead.
+  /// Colors resolve from the ambient brightness so the overlay matches the
+  /// native title in light and dark mode.
+  Widget? _buildIOS26TitleOverlay() {
+    return _buildAppBarTitle(
+      nativeTitleFallback: true,
+      titleStyle: TextStyle(
+        fontSize: 17,
+        fontWeight: FontWeight.w600,
+        color: CupertinoColors.label.resolveFrom(context),
+      ),
+      subtitleColor: CupertinoColors.secondaryLabel.resolveFrom(context),
     );
   }
 
@@ -369,7 +352,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
                 PlatformInfo.isIOS26OrHigher() && useNativeToolbar
                 ? false
                 : true, // Let CupertinoNavigationBar handle back button naturally
-            middle: _buildTitleWidget(),
+            middle: _buildAppBarTitle(),
             trailing:
                 widget.appBar!.actions != null &&
                     widget.appBar!.actions!.isNotEmpty
@@ -567,7 +550,7 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
               PlatformInfo.isIOS26OrHigher() && useNativeToolbar
               ? false
               : true, // Let CupertinoNavigationBar handle back button naturally
-          middle: _buildTitleWidget(),
+          middle: _buildAppBarTitle(),
           trailing:
               widget.appBar!.actions != null &&
                   widget.appBar!.actions!.isNotEmpty
@@ -651,7 +634,13 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
                   widget.appBar!.actions!.isNotEmpty) ||
               widget.appBar!.leading != null)) {
         appBar = AppBar(
-          title: _buildMaterialTitleWidget(),
+          title: _buildAppBarTitle(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            subtitleFontSize: 13,
+            subtitleColor: Theme.of(
+              context,
+            ).textTheme.bodySmall?.color?.withValues(alpha: 0.7),
+          ),
           centerTitle: widget.appBar!.titleWidget != null,
           actions: widget.appBar!.actions?.map((action) {
             if (action.title != null) {
@@ -745,7 +734,13 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
     // Priority 2: Build AppBar if widget.appBar is provided (even if empty - for automatic back button)
     else if (widget.appBar != null) {
       appBar = AppBar(
-        title: _buildMaterialTitleWidget(),
+        title: _buildAppBarTitle(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          subtitleFontSize: 13,
+          subtitleColor: Theme.of(
+            context,
+          ).textTheme.bodySmall?.color?.withValues(alpha: 0.7),
+        ),
         centerTitle: widget.appBar!.titleWidget != null,
         actions: widget.appBar!.actions?.map((action) {
           if (action.title != null) {

--- a/lib/src/widgets/ios26/ios26_native_toolbar.dart
+++ b/lib/src/widgets/ios26/ios26_native_toolbar.dart
@@ -16,6 +16,7 @@ class IOS26NativeToolbar extends StatefulWidget {
     this.actions,
     this.onLeadingTap,
     this.onActionTap,
+    this.titleWidget,
     this.tintColor,
     this.height = 44.0,
     this.showNativeView = true,
@@ -27,6 +28,10 @@ class IOS26NativeToolbar extends StatefulWidget {
   final List<AdaptiveAppBarAction>? actions;
   final VoidCallback? onLeadingTap;
   final ValueChanged<int>? onActionTap;
+
+  /// Custom widget overlaid at the title position.
+  /// When set, the native title is hidden and this widget is centered instead.
+  final Widget? titleWidget;
 
   /// Tint color for bar button items (action buttons and back button)
   ///
@@ -79,7 +84,8 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
 
     if (widget.title != oldWidget.title) {
       final ch = _channel;
-      if (ch != null && widget.title != null) {
+      // Skip when a titleWidget overlay is shown — the native title stays hidden
+      if (ch != null && widget.title != null && widget.titleWidget == null) {
         ch.invokeMethod('updateTitle', {'title': widget.title!});
       }
     }
@@ -148,7 +154,9 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
     final safePadding = MediaQuery.of(context).padding.top;
 
     final creationParams = <String, dynamic>{
-      if (widget.title != null) 'title': widget.title!,
+      // Hide native title when a titleWidget overlay is provided
+      if (widget.title != null && widget.titleWidget == null)
+        'title': widget.title!,
       if (widget.leading == null && widget.leadingText != null)
         'leading': widget.leadingText!,
       if (widget.actions != null && widget.actions!.isNotEmpty)
@@ -179,6 +187,14 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
                 alignment: Alignment.centerLeft,
                 child: widget.leading!,
               ),
+            ),
+          if (widget.titleWidget != null)
+            Positioned(
+              left: 0,
+              right: 0,
+              top: safePadding,
+              bottom: 0,
+              child: Center(child: widget.titleWidget!),
             ),
         ],
       ),
@@ -211,7 +227,8 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
 
   Widget _buildFallbackToolbar() {
     return CupertinoNavigationBar(
-      middle: widget.title != null ? Text(widget.title!) : null,
+      middle: widget.titleWidget ??
+          (widget.title != null ? Text(widget.title!) : null),
       leading: widget.leading,
       trailing: widget.actions != null && widget.actions!.isNotEmpty
           ? Row(

--- a/lib/src/widgets/ios26/ios26_scaffold.dart
+++ b/lib/src/widgets/ios26/ios26_scaffold.dart
@@ -16,6 +16,7 @@ class IOS26Scaffold extends StatefulWidget {
     this.actions,
     this.leading,
     this.tintColor,
+    this.titleWidget,
     this.minimizeBehavior = TabBarMinimizeBehavior.automatic,
     this.enableBlur = true,
     this.useHeroBackButton = true,
@@ -29,6 +30,10 @@ class IOS26Scaffold extends StatefulWidget {
   final List<AdaptiveAppBarAction>? actions;
   final Widget? leading;
   final Color? tintColor;
+
+  /// Custom widget overlaid at the toolbar's title position.
+  /// When set, the native title is hidden and this widget is centered instead.
+  final Widget? titleWidget;
   final TabBarMinimizeBehavior minimizeBehavior;
   final bool enableBlur;
   final bool useHeroBackButton;
@@ -177,6 +182,7 @@ class _IOS26ScaffoldState extends State<IOS26Scaffold>
     // Only the underlying UiKitView should be hidden.
     final hasToolbarContent =
         (widget.title != null ||
+        widget.titleWidget != null ||
         widget.leading != null ||
         heroLeading != null ||
         (widget.actions != null && widget.actions!.isNotEmpty));
@@ -220,6 +226,7 @@ class _IOS26ScaffoldState extends State<IOS26Scaffold>
               showNativeView: showNativeView,
               actions: widget.actions,
               tintColor: widget.tintColor,
+              titleWidget: widget.titleWidget,
               onActionTap: (index) {
                 // Call the appropriate action callback
                 if (widget.actions != null &&


### PR DESCRIPTION
## What

Adds two optional fields to `AdaptiveAppBar` (plus `copyWith` support):

- **`subtitle`** — a smaller second line below the title.
- **`titleWidget`** — replaces the title area with an arbitrary widget (e.g. an avatar + name row).

## How it renders per platform

| Path | subtitle | titleWidget |
|---|---|---|
| iOS 26+ native toolbar | Centered Flutter overlay (native title is a plain string and can't show two lines); native title is hidden | Centered Flutter overlay; native title hidden |
| iOS <26 `CupertinoNavigationBar` | Two-line `middle` | Used as `middle` |
| Material `AppBar` | Two-line `title` (subtitle dimmed) | Used as `title` with `centerTitle` |

## Implementation notes

- `IOS26NativeToolbar` gains a `titleWidget` param; when set, the `title` creation param is omitted and the dynamic `updateTitle` sync is skipped so the native title stays hidden.
- When only `title` is set, behavior is unchanged (native title renders natively).
- Backward compatible — both fields default to `null`.

## Example & tests

- Example app: new **App Bar Title** demo page with a live plain/subtitle/custom switcher (route + home entry included).
- Full test suite passes (221/221).

🤖 Generated with [Claude Code](https://claude.com/claude-code)