### PR TITLE
fix: sync iOS status bar style with effective theme brightness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+* **FIX**: iOS status bar icons now follow the effective theme brightness — `AdaptiveApp`'s Cupertino path wraps the app in an `AnnotatedRegion<SystemUiOverlayStyle>`, so forcing a `ThemeMode` different from the system brightness no longer leaves the status bar unreadable (@luflow)
+
 ## [0.1.109]
 * **NEW**: `triggerOnLongPress` and `onTap` on popup menu buttons — tap fires `onTap`, long-press opens the menu (@yuriylybimov)
 * **NEW**: `isDestructive` on `AdaptivePopupMenuItem` — renders destructive (red) styling on Material, iOS <26, and iOS 26+ native menus (@yuriylybimov)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Changelog
 
-## [Unreleased]
-* **FIX**: iOS status bar icons now follow the effective theme brightness — `AdaptiveApp`'s Cupertino path wraps the app in an `AnnotatedRegion<SystemUiOverlayStyle>`, so forcing a `ThemeMode` different from the system brightness no longer leaves the status bar unreadable (@luflow)
-
 ## [0.1.109]
 * **NEW**: `triggerOnLongPress` and `onTap` on popup menu buttons — tap fires `onTap`, long-press opens the menu (@yuriylybimov)
 * **NEW**: `isDestructive` on `AdaptivePopupMenuItem` — renders destructive (red) styling on Material, iOS <26, and iOS 26+ native menus (@yuriylybimov)

--- a/lib/src/widgets/adaptive_app.dart
+++ b/lib/src/widgets/adaptive_app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import '../platform/platform_info.dart';
 
 /// Platform-specific configuration for MaterialApp
@@ -298,7 +299,15 @@ class AdaptiveApp extends StatelessWidget {
         data: MediaQuery.of(
           context,
         ).copyWith(platformBrightness: effectiveBrightness),
-        child: CupertinoTheme(data: theme, child: child!),
+        // Keep the status bar legible: light icons on dark backgrounds and
+        // vice versa. Without this, forcing a ThemeMode that differs from the
+        // system brightness leaves the status bar in the wrong style.
+        child: AnnotatedRegion<SystemUiOverlayStyle>(
+          value: isDark
+              ? SystemUiOverlayStyle.light
+              : SystemUiOverlayStyle.dark,
+          child: CupertinoTheme(data: theme, child: child!),
+        ),
       );
     }
 


### PR DESCRIPTION
## Problem

When `AdaptiveApp` (Cupertino path) forces a `ThemeMode` that differs from the system brightness — e.g. `ThemeMode.dark` while the device is in light mode — the status bar keeps the system's style and becomes unreadable (dark icons on a dark background).

## Fix

Wrap the Cupertino app in an `AnnotatedRegion<SystemUiOverlayStyle>` derived from the *effective* brightness (the same one used to pick the theme), so status bar icons are always light-on-dark / dark-on-light. The Material path already gets this for free from `AppBar`/`ThemeData`.

Full test suite passes (221/221).

🤖 Generated with [Claude Code](https://claude.com/claude-code)