### PR TITLE
fix: iOS 26 popup button unbounded-Row crash + button Auto Layout warning

### DIFF
--- a/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26ButtonView.swift
+++ b/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26ButtonView.swift
@@ -129,12 +129,20 @@ class iOS26ButtonView: NSObject, FlutterPlatformView {
         _view.addSubview(button)
 
         // Button should fill container width
+        // The top+bottom pins already tie the button's height to the
+        // container. Keep the explicit height as a *preference* (lower than
+        // required) so it acts as an intrinsic size when nothing else drives
+        // the height, but yields to the container when they differ — otherwise
+        // a container that is a couple of points taller/shorter produces an
+        // "unable to simultaneously satisfy constraints" log every layout pass.
+        let heightConstraint = button.heightAnchor.constraint(equalToConstant: getHeightForSize())
+        heightConstraint.priority = .defaultHigh
         NSLayoutConstraint.activate([
             button.leadingAnchor.constraint(equalTo: _view.leadingAnchor),
             button.trailingAnchor.constraint(equalTo: _view.trailingAnchor),
             button.topAnchor.constraint(equalTo: _view.topAnchor),
             button.bottomAnchor.constraint(equalTo: _view.bottomAnchor),
-            button.heightAnchor.constraint(equalToConstant: getHeightForSize())
+            heightConstraint
         ])
 
         // Low content hugging - button can expand if container wants

--- a/lib/src/widgets/ios26/ios26_popup_menu_button.dart
+++ b/lib/src/widgets/ios26/ios26_popup_menu_button.dart
@@ -4,6 +4,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 
+/// Placeholder width used for a text/standard popup button when it is laid out
+/// in an unbounded-width context before its native intrinsic width has been
+/// measured. It resizes to the real width once UIKit reports it.
+const double _kUnboundedFallbackWidth = 120.0;
+
 /// Base type for entries in a popup menu
 abstract class AdaptivePopupMenuEntry {
   /// Const constructor for subclasses
@@ -418,6 +423,16 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
             width = widget.width ?? widget.height;
           } else if (preferIntrinsic) {
             width = _intrinsicWidth;
+          }
+
+          // In an unbounded-width context (e.g. placed directly inside a Row)
+          // the native platform view would try to expand to infinity before
+          // its intrinsic width has been reported back from UIKit, throwing an
+          // unbounded-constraints error on the first frame. Fall back to a
+          // finite placeholder width until the real width arrives; it resizes
+          // via setState once measured.
+          if (!hasBoundedWidth && widget.width == null && width == null) {
+            width = _kUnboundedFallbackWidth;
           }
 
           return SizedBox(


### PR DESCRIPTION
Two iOS 26 layout fixes surfaced while running the example app.

## 1. Unbounded-width crash for the text popup button (Dart)
`IOS26PopupMenuButton` measures its intrinsic width asynchronously from the native platform view. On the first frame that width is `null`, so when the button is placed in an unbounded-width context (e.g. directly inside a `Row`, as in the popup demo's "Dynamic Label Test") the `SizedBox` width resolved to `null` and the `UiKitView` expanded to infinity, throwing `RenderConstrainedBox object was given an infinite size during layout`.

Fix: fall back to a finite placeholder width only in that specific case (unbounded + no explicit width + intrinsic not yet measured) until the real width arrives via `setState`. All bounded / already-measured / icon / widget paths are unchanged.

## 2. Native button Auto Layout conflict (Swift)
`iOS26ButtonView` pinned the `UIButton` top+bottom to its container and also gave it a required explicit height. When the container height differs by a couple of points (a 38pt container vs a 36pt button height) UIKit logged `Unable to simultaneously satisfy constraints` every layout pass, recovering by breaking the height.

Fix: lower the explicit height constraint to `.defaultHigh` so it yields to the container pins. No visible change (the button already ended up at the container height); the log spam is gone.

Both are pre-existing issues, independent of any recent feature PR.