### PR TITLE
fix: deliver taps to the iOS 26 native tab bar

### DIFF
--- a/lib/src/widgets/ios26/ios26_native_tab_bar.dart
+++ b/lib/src/widgets/ios26/ios26_native_tab_bar.dart
@@ -220,8 +220,17 @@ class _IOS26NativeTabBarState extends State<IOS26NativeTabBar> {
               creationParams: creationParams,
               creationParamsCodec: const StandardMessageCodec(),
               onPlatformViewCreated: _onCreated,
+              // A TapGestureRecognizer only claims the arena on pointer-up,
+              // by which time Flutter has already cancelled the touch
+              // sequence on the embedded UITabBar — the hit test lands on the
+              // right _UITabButton but `didSelect` never fires. Claiming
+              // eagerly hands the whole sequence to UIKit, which restores the
+              // press highlight and the drag-between-tabs gesture along with
+              // plain taps.
               gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{
-                Factory<TapGestureRecognizer>(() => TapGestureRecognizer()),
+                Factory<OneSequenceGestureRecognizer>(
+                  () => EagerGestureRecognizer(),
+                ),
               },
             )
           : const SizedBox.shrink();


### PR DESCRIPTION
## Problem

With `useNativeBottomBar: true` on iOS 26, the native tab bar renders correctly but **every tap on it is silently dropped** — the selection never moves and `onTap` never fires. There is no error and nothing in the logs; the bar simply does not respond.

## Diagnosis

I instrumented `iOS26TabBarPlatformView` to find where the touch is lost:

- `LayoutAwareTabBarContainerView.hitTest` **does** run and returns the correct button:
  ```
  container.hitTest point=(139.5, 34.4) bounds=(0, 0, 402, 83)
    hit=<_UITabButton: frame = (89.6667 4; 95 54)>
  ```
- `UITabBarDelegate.tabBar(_:didSelect:)` **never runs**, so `channel.invokeMethod("valueChanged", …)` is never reached.

So UIKit routes the touch to the right button, but the button never completes its action — the sequence is cancelled before pointer-up.

The cause is on the Flutter side. The platform view declares:

```dart
gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{
  Factory<TapGestureRecognizer>(() => TapGestureRecognizer()),
},
```

`TapGestureRecognizer` only declares victory in the gesture arena **on pointer-up**. While it waits, Flutter's touch interceptor — which has been delaying the sequence — cancels it on the embedded `UITabBar`.

## Fix

Claim the sequence eagerly, so it is handed to UIKit as soon as it begins:

```dart
gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{
  Factory<OneSequenceGestureRecognizer>(() => EagerGestureRecognizer()),
},
```

This is the documented approach for platform views that own their own gestures, and it restores the full native behaviour — the press highlight and the drag-between-tabs gesture, not just plain taps.

## Testing

Reproduced and verified on an iPhone 17 simulator (iOS 26), before and after, in an app using `AdaptiveScaffold` + `AdaptiveBottomNavigationBar` with four destinations:

- before — taps do nothing on any destination
- after — taps switch destinations, press-and-hold highlights, dragging across the bar moves the selection

One line changed, iOS-only path, no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)