### PR TITLE
feat: section titles in menus, and menus on app bar actions

### DIFF
--- a/example/lib/pages/demos/popup_menu_demo_page.dart
+++ b/example/lib/pages/demos/popup_menu_demo_page.dart
@@ -411,7 +411,7 @@ class _PopupMenuDemoPageState extends State<PopupMenuDemoPage> {
                 icon: PlatformInfo.isIOS26OrHigher() ? 'folder' : Icons.folder,
                 value: 'open',
               ),
-              AdaptivePopupMenuDivider(),
+              AdaptivePopupMenuDivider(title: 'Saving'),
               AdaptivePopupMenuItem(
                 label: 'Save',
                 icon: PlatformInfo.isIOS26OrHigher()
@@ -426,7 +426,7 @@ class _PopupMenuDemoPageState extends State<PopupMenuDemoPage> {
                     : Icons.save_as_sharp,
                 value: 'save_as',
               ),
-              AdaptivePopupMenuDivider(),
+              AdaptivePopupMenuDivider(title: 'Window'),
               AdaptivePopupMenuItem(
                 label: 'Close',
                 icon: PlatformInfo.isIOS26OrHigher() ? 'xmark' : Icons.close,

--- a/example/lib/pages/demos/toolbar_tint_demo_page.dart
+++ b/example/lib/pages/demos/toolbar_tint_demo_page.dart
@@ -13,6 +13,7 @@ class _ToolbarTintDemoPageState extends State<ToolbarTintDemoPage> {
   int _selectedColorIndex = 0;
   int _checkmarkTintIndex = 2; // Green by default
   int _heartTintIndex = 1; // Red by default
+  String? _lastMenuSelection;
 
   static const _tintOptions = <_TintOption>[
     _TintOption(name: 'Blue', color: Colors.blue),
@@ -63,6 +64,36 @@ class _ToolbarTintDemoPageState extends State<ToolbarTintDemoPage> {
             tintColor: _heartTint,
             onPressed: () {},
           ),
+          // Action that opens a menu instead of firing onPressed — a native
+          // UIMenu with titled inline sections on iOS 26+.
+          AdaptiveAppBarAction(
+            iosSymbol: 'ellipsis.circle',
+            icon: Icons.more_vert,
+            onPressed: () {},
+            menuItems: const [
+              AdaptivePopupMenuDivider(title: 'Edit'),
+              AdaptivePopupMenuItem(
+                label: 'Rename',
+                icon: 'pencil',
+                value: 'rename',
+              ),
+              AdaptivePopupMenuItem(
+                label: 'Duplicate',
+                icon: 'doc.on.doc',
+                value: 'duplicate',
+              ),
+              AdaptivePopupMenuDivider(title: 'Danger'),
+              AdaptivePopupMenuItem(
+                label: 'Delete',
+                icon: 'trash',
+                isDestructive: true,
+                value: 'delete',
+              ),
+            ],
+            onMenuSelected: (index, entry) {
+              setState(() => _lastMenuSelection = entry.label);
+            },
+          ),
         ],
       ),
       body: _buildBody(context),
@@ -80,6 +111,24 @@ class _ToolbarTintDemoPageState extends State<ToolbarTintDemoPage> {
       child: ListView(
         padding: const EdgeInsets.fromLTRB(16, 120, 16, 32),
         children: [
+          _buildSectionHeader(context, 'Action Menu', isDark),
+          const SizedBox(height: 8),
+          _buildDescription(
+            context,
+            'The last toolbar action opens a menu instead of firing '
+            'onPressed. On iOS 26+ it is a native UIMenu whose sections carry '
+            'the titles given to AdaptivePopupMenuDivider.',
+            isDark,
+          ),
+          const SizedBox(height: 8),
+          _buildDescription(
+            context,
+            _lastMenuSelection == null
+                ? 'Nothing picked yet.'
+                : 'Picked: $_lastMenuSelection',
+            isDark,
+          ),
+          const SizedBox(height: 24),
           _buildSectionHeader(context, 'Global Tint Color', isDark),
           const SizedBox(height: 8),
           _buildDescription(

--- a/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26PopupMenuButtonView.swift
+++ b/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26PopupMenuButtonView.swift
@@ -186,11 +186,20 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
         // iOS 14+ native menu
         if #available(iOS 14.0, *) {
             var groups: [[UIMenuElement]] = []
+            var groupTitles: [String] = []
+            // A divider carries the title of the group that follows it, so the
+            // one waiting here belongs to whatever is collected next.
+            var pendingTitle = ""
             var current: [UIMenuElement] = []
             let count = max(labels.count, max(symbols.count, dividers.count))
 
             let flushGroup: () -> Void = {
-                if !current.isEmpty { groups.append(current); current = [] }
+                if !current.isEmpty {
+                    groups.append(current)
+                    groupTitles.append(pendingTitle)
+                    current = []
+                    pendingTitle = ""
+                }
             }
 
             // Count only selectable items for indexing
@@ -198,7 +207,11 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
 
             for i in 0..<count {
                 let isDiv = i < dividers.count ? dividers[i] : false
-                if isDiv { flushGroup(); continue }
+                if isDiv {
+                    flushGroup()
+                    pendingTitle = i < labels.count ? labels[i] : ""
+                    continue
+                }
 
                 let title = i < labels.count ? labels[i] : ""
                 let subtitle = i < subtitles.count ? subtitles[i] : ""
@@ -232,8 +245,8 @@ class iOS26PopupMenuButtonView: NSObject, FlutterPlatformView {
             }
             flushGroup()
 
-            let children: [UIMenuElement] = groups.map { group in
-                UIMenu(title: "", options: .displayInline, children: group)
+            let children: [UIMenuElement] = groups.enumerated().map { index, group in
+                UIMenu(title: groupTitles[index], options: .displayInline, children: group)
             }
             button.menu = UIMenu(title: "", children: children)
         }

--- a/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26ToolbarPlatformView.swift
+++ b/ios/adaptive_platform_ui/Sources/adaptive_platform_ui/iOS26ToolbarPlatformView.swift
@@ -231,6 +231,15 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
                 if let btn = button {
                     btn.tag = index
 
+                    // An action carrying menu entries opens them natively
+                    // instead of calling back into Dart on every tap.
+                    if #available(iOS 14.0, *),
+                       let entries = action["menu"] as? [[String: Any]] {
+                        btn.menu = buildMenu(entries, actionIndex: index)
+                        btn.target = nil
+                        btn.action = nil
+                    }
+
                     // Apply prominent style (iOS 26+)
                     if action["prominent"] as? Bool == true {
                         if #available(iOS 26.0, *) {
@@ -287,6 +296,79 @@ class iOS26ToolbarPlatformView: NSObject, FlutterPlatformView {
 
     @objc private func actionTapped(_ sender: UIBarButtonItem) {
         channel.invokeMethod("onActionTapped", arguments: ["index": sender.tag])
+    }
+
+    /// Builds the menu of one toolbar action. Entries marked as dividers end
+    /// the current section and name the one that follows, which is how an
+    /// inline UIMenu carries a section title.
+    @available(iOS 14.0, *)
+    private func buildMenu(_ entries: [[String: Any]], actionIndex: Int) -> UIMenu {
+        var groups: [[UIMenuElement]] = []
+        var groupTitles: [String] = []
+        var current: [UIMenuElement] = []
+        var pendingTitle = ""
+        var selectableIndex = 0
+
+        let flushGroup: () -> Void = {
+            if !current.isEmpty {
+                groups.append(current)
+                groupTitles.append(pendingTitle)
+                current = []
+                pendingTitle = ""
+            }
+        }
+
+        for entry in entries {
+            if entry["isDivider"] as? Bool == true {
+                flushGroup()
+                pendingTitle = entry["label"] as? String ?? ""
+                continue
+            }
+
+            let label = entry["label"] as? String ?? ""
+            let subtitle = entry["subtitle"] as? String ?? ""
+            let symbol = entry["icon"] as? String ?? ""
+            let isEnabled = entry["enabled"] as? Bool ?? true
+            let isDestructive = entry["isDestructive"] as? Bool ?? false
+            var attributes: UIMenuElement.Attributes = isEnabled ? [] : [.disabled]
+            if isDestructive { attributes.insert(.destructive) }
+            let image = symbol.isEmpty ? nil : UIImage(systemName: symbol)
+            let itemIndex = selectableIndex
+            selectableIndex += 1
+
+            let handler: (UIAction) -> Void = { [weak self] _ in
+                self?.channel.invokeMethod(
+                    "onMenuItemSelected",
+                    arguments: ["index": actionIndex, "itemIndex": itemIndex]
+                )
+            }
+
+            let uiAction: UIAction
+            if #available(iOS 15.0, *), !subtitle.isEmpty {
+                uiAction = UIAction(
+                    title: label,
+                    subtitle: subtitle,
+                    image: image,
+                    attributes: attributes,
+                    handler: handler
+                )
+            } else {
+                uiAction = UIAction(
+                    title: label,
+                    image: image,
+                    attributes: attributes,
+                    handler: handler
+                )
+            }
+            current.append(uiAction)
+        }
+        flushGroup()
+
+        let children: [UIMenuElement] = groups.enumerated().map { index, group in
+            UIMenu(title: groupTitles[index], options: .displayInline, children: group)
+        }
+
+        return UIMenu(title: "", children: children)
     }
 
     private func handleMethodCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/lib/src/widgets/adaptive_app_bar_action.dart
+++ b/lib/src/widgets/adaptive_app_bar_action.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
+import 'ios26/ios26_popup_menu_button.dart';
+
 /// Spacer type for toolbar items (iOS 26+ only)
 enum ToolbarSpacerType {
   /// No spacer
@@ -25,6 +27,8 @@ class AdaptiveAppBarAction {
     this.iconWidget,
     this.title,
     required this.onPressed,
+    this.menuItems,
+    this.onMenuSelected,
     this.spacerAfter = ToolbarSpacerType.none,
     this.prominent = false,
     this.tintColor,
@@ -99,13 +103,47 @@ class AdaptiveAppBarAction {
   int get hashCode => Object.hash(iosSymbol, icon, iconWidget, title, prominent, tintColor);
 
   /// Convert action to map for native platform channel (iOS 26+ only)
+  /// Menu entries this action opens instead of firing [onPressed]
+  ///
+  /// - On iOS 26+: attached to the native UIBarButtonItem as a UIMenu, so the
+  ///   toolbar button opens a native menu rather than calling back into Dart
+  /// - On iOS < 26 and Android: rendered through [AdaptivePopupMenuButton]
+  ///
+  /// [AdaptivePopupMenuDivider.title] groups the entries into titled sections.
+  final List<AdaptivePopupMenuEntry>? menuItems;
+
+  /// Called with the entry the user picked from [menuItems]
+  final void Function(int index, AdaptivePopupMenuItem entry)? onMenuSelected;
+
+  /// Whether this action opens a menu rather than firing [onPressed]
+  bool get hasMenu => menuItems != null && menuItems!.isNotEmpty;
+
   Map<String, dynamic> toNativeMap() {
     return {
       if (iosSymbol != null) 'icon': iosSymbol!,
       if (title != null) 'title': title!,
+      if (hasMenu) 'menu': _menuToNativeList(),
       'spacerAfter': spacerAfter.index, // 0=none, 1=fixed, 2=flexible
       if (prominent) 'prominent': true,
       if (tintColor != null) 'tint': tintColor!.toARGB32(),
     };
+  }
+
+  List<Map<String, dynamic>> _menuToNativeList() {
+    return [
+      for (final entry in menuItems!)
+        if (entry is AdaptivePopupMenuDivider)
+          // The title rides along with the divider, naming the group after it.
+          {'label': entry.title ?? '', 'isDivider': true, 'enabled': false}
+        else if (entry is AdaptivePopupMenuItem)
+          {
+            'label': entry.label,
+            'subtitle': entry.subtitle ?? '',
+            'icon': entry.icon is String ? entry.icon as String : '',
+            'isDivider': false,
+            'enabled': entry.enabled,
+            'isDestructive': entry.isDestructive,
+          },
+    ];
   }
 }

--- a/lib/src/widgets/adaptive_popup_menu_button.dart
+++ b/lib/src/widgets/adaptive_popup_menu_button.dart
@@ -205,6 +205,32 @@ class AdaptivePopupMenuButton<T> {
     );
   }
 
+  /// The gap between two groups in the action sheet, carrying the group's
+  /// title when the divider has one — the sheet has no section of its own.
+  static Widget _buildSheetDivider(
+    BuildContext context,
+    AdaptivePopupMenuEntry entry,
+  ) {
+    final title = entry is AdaptivePopupMenuDivider ? entry.title : null;
+    if (title == null || title.isEmpty) return const SizedBox(height: 8);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 6),
+      child: SizedBox(
+        width: double.infinity,
+        child: Text(
+          title,
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w600,
+            color: CupertinoColors.secondaryLabel.resolveFrom(context),
+          ),
+        ),
+      ),
+    );
+  }
+
   static Future<void> _showMenu<T>(
     BuildContext context,
     String? title,
@@ -227,7 +253,7 @@ class AdaptivePopupMenuButton<T> {
                   ),
                 )
               else
-                const SizedBox(height: 8),
+                _buildSheetDivider(ctx, items[i]),
           ],
           cancelButton: CupertinoActionSheetAction(
             onPressed: () => Navigator.of(ctx).pop(),
@@ -308,7 +334,21 @@ class _MaterialPopupMenuButtonState<T>
 
     for (var i = 0; i < widget.items.length; i++) {
       if (widget.items[i] is AdaptivePopupMenuDivider) {
-        menuItems.add(const PopupMenuDivider());
+        final divider = widget.items[i] as AdaptivePopupMenuDivider;
+        final title = divider.title;
+        if (i > 0) menuItems.add(const PopupMenuDivider());
+        if (title != null && title.isNotEmpty) {
+          menuItems.add(
+            PopupMenuItem<int>(
+              enabled: false,
+              height: 32,
+              child: Text(
+                title,
+                style: Theme.of(context).textTheme.labelMedium,
+              ),
+            ),
+          );
+        }
       } else if (widget.items[i] is AdaptivePopupMenuItem<T>) {
         final item = widget.items[i] as AdaptivePopupMenuItem<T>;
         final labelStyle = item.isDestructive

--- a/lib/src/widgets/adaptive_scaffold.dart
+++ b/lib/src/widgets/adaptive_scaffold.dart
@@ -4,9 +4,11 @@ import 'package:flutter/material.dart';
 import '../platform/platform_info.dart';
 import '../style/sf_symbol.dart';
 import 'adaptive_app_bar.dart';
+import 'adaptive_app_bar_action.dart';
 import 'adaptive_badge.dart';
 import 'adaptive_bottom_navigation_bar.dart';
 import 'adaptive_button.dart';
+import 'adaptive_popup_menu_button.dart';
 import 'ios26/ios26_scaffold.dart';
 
 /// Navigation destination for bottom navigation
@@ -373,6 +375,9 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
                       } else {
                         actionChild = const Icon(CupertinoIcons.circle);
                       }
+                      if (action.hasMenu) {
+                        return _menuButton(action, actionChild);
+                      }
                       return CupertinoButton(
                         padding: EdgeInsets.zero,
                         onPressed: action.onPressed,
@@ -573,6 +578,9 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
                     } else {
                       actionChild = const Icon(CupertinoIcons.circle);
                     }
+                    if (action.hasMenu) {
+                      return _menuButton(action, actionChild);
+                    }
                     return CupertinoButton(
                       padding: EdgeInsets.zero,
                       onPressed: action.onPressed,
@@ -651,6 +659,14 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
           ),
           centerTitle: widget.appBar!.titleWidget != null,
           actions: widget.appBar!.actions?.map((action) {
+            if (action.hasMenu) {
+              return _menuButton(
+                action,
+                action.title != null
+                    ? Text(action.title!)
+                    : (action.iconWidget ?? Icon(action.icon ?? Icons.circle)),
+              );
+            }
             if (action.title != null) {
               return TextButton(
                 onPressed: action.onPressed,
@@ -751,6 +767,14 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
         ),
         centerTitle: widget.appBar!.titleWidget != null,
         actions: widget.appBar!.actions?.map((action) {
+          if (action.hasMenu) {
+            return _menuButton(
+              action,
+              action.title != null
+                  ? Text(action.title!)
+                  : (action.iconWidget ?? Icon(action.icon ?? Icons.circle)),
+            );
+          }
           if (action.title != null) {
             return TextButton(
               onPressed: action.onPressed,
@@ -812,6 +836,17 @@ class _AdaptiveScaffoldState extends State<AdaptiveScaffold> {
       'checkmark.circle': CupertinoIcons.checkmark_circle,
     };
     return iconMap[sfSymbol] ?? CupertinoIcons.circle;
+  }
+
+  /// An app bar action carrying menu entries opens them instead of firing
+  /// onPressed. iOS 26 hands its own menu to the native toolbar button, so
+  /// this path only serves iOS < 26 and Android.
+  Widget _menuButton(AdaptiveAppBarAction action, Widget child) {
+    return AdaptivePopupMenuButton.widget<dynamic>(
+      items: action.menuItems!,
+      onSelected: (index, entry) => action.onMenuSelected?.call(index, entry),
+      child: child,
+    );
   }
 
   Widget _buildNavigationIconWidget({

--- a/lib/src/widgets/ios26/ios26_native_toolbar.dart
+++ b/lib/src/widgets/ios26/ios26_native_toolbar.dart
@@ -2,6 +2,8 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+
+import 'ios26_popup_menu_button.dart';
 import '../../utils/animation.dart';
 import '../adaptive_app_bar_action.dart';
 
@@ -211,6 +213,28 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
         widget.actions != null ? List.of(widget.actions!) : null;
   }
 
+  /// The native menu reports the position among the selectable entries, so
+  /// dividers have to be skipped to land on the entry Dart handed over.
+  void _notifyMenuSelection(int actionIndex, int itemIndex) {
+    final actions = widget.actions;
+    if (actions == null || actionIndex >= actions.length) return;
+
+    final action = actions[actionIndex];
+    final items = action.menuItems;
+    if (items == null) return;
+
+    var selectable = 0;
+    for (var i = 0; i < items.length; i++) {
+      final entry = items[i];
+      if (entry is! AdaptivePopupMenuItem) continue;
+      if (selectable == itemIndex) {
+        action.onMenuSelected?.call(i, entry);
+        return;
+      }
+      selectable++;
+    }
+  }
+
   Future<dynamic> _handleMethodCall(MethodCall call) async {
     switch (call.method) {
       case 'onLeadingTapped':
@@ -220,6 +244,16 @@ class _IOS26NativeToolbarState extends State<IOS26NativeToolbar> {
         if (call.arguments is Map) {
           final index = (call.arguments as Map)['index'] as int?;
           if (index != null) widget.onActionTap?.call(index);
+        }
+        break;
+      case 'onMenuItemSelected':
+        if (call.arguments is Map) {
+          final args = call.arguments as Map;
+          final index = args['index'] as int?;
+          final itemIndex = args['itemIndex'] as int?;
+          if (index != null && itemIndex != null) {
+            _notifyMenuSelection(index, itemIndex);
+          }
         }
         break;
     }

--- a/lib/src/widgets/ios26/ios26_popup_menu_button.dart
+++ b/lib/src/widgets/ios26/ios26_popup_menu_button.dart
@@ -54,7 +54,15 @@ class AdaptivePopupMenuItem<T> extends AdaptivePopupMenuEntry {
 /// A visual divider between popup menu items
 class AdaptivePopupMenuDivider extends AdaptivePopupMenuEntry {
   /// Creates a visual divider between items
-  const AdaptivePopupMenuDivider();
+  ///
+  /// [title] names the group that follows it. On iOS 26+ it becomes the title
+  /// of the inline UIMenu section, which is where the platform puts such a
+  /// label. A divider placed before the first item titles that first group
+  /// without drawing a separator.
+  const AdaptivePopupMenuDivider({this.title});
+
+  /// Optional title for the group that follows this divider
+  final String? title;
 }
 
 /// Button style for popup menu button
@@ -268,7 +276,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
 
     for (final e in widget.items) {
       if (e is AdaptivePopupMenuDivider) {
-        labels.add('');
+        labels.add(e.title ?? '');
         subtitles.add('');
         symbols.add('');
         imageData.add(null);
@@ -329,7 +337,7 @@ class _IOS26PopupMenuButtonState<T> extends State<IOS26PopupMenuButton<T>> {
 
       for (final e in widget.items) {
         if (e is AdaptivePopupMenuDivider) {
-          labels.add('');
+          labels.add(e.title ?? '');
           subtitles.add('');
           symbols.add('');
           imageData.add(null);


### PR DESCRIPTION
Two related additions, both coming out of building a crowded ⋮ menu in a real app.

## 1. `AdaptivePopupMenuDivider({String? title})`

The iOS 26 menu already splits its items into groups on every divider and renders each group as `UIMenu(title: "", options: .displayInline, …)`. The API just had no way to fill that title, so a menu with three groups could separate them but not name them.

A divider's `title` names the group that **follows** it, which means a divider placed before the first item titles that first group without drawing a separator.

- **iOS 26+:** the inline `UIMenu` section title — where the platform itself puts such a label
- **iOS <26:** heads the group inside the action sheet (centered, like the sheet's own title)
- **Android:** a disabled heading row above the group, styled from `Theme.textTheme.labelMedium`

The title rides along in the existing `labels` slot, which was empty for dividers — no new field on the platform channel.

## 2. `AdaptiveAppBarAction.menuItems` / `onMenuSelected`

An app bar action could only fire `onPressed`. To open a menu from the app bar you had to build one per platform yourself — and on iOS 26 you cannot build it at all, because the toolbar is native and will not host a Flutter menu widget. That leaves the toolbar's ⋮ as the one menu in an app that never gets the native `UIMenu` treatment every other menu gets.

With `menuItems` set, the action attaches its entries to the `UIBarButtonItem` as a `UIMenu` (selection reported back over the existing toolbar channel, mapped past dividers to the entry Dart handed over). On iOS <26 and Android the same entries go through `AdaptivePopupMenuButton`, so all four render paths in `AdaptiveScaffold` behave the same.

The existing `isDestructive` flag is carried through the new toolbar payload and becomes `.destructive` in the native menu.

## Demos

- Popup menu demo: the "With Dividers" example now titles its groups (`Saving`, `Window`)
- Toolbar tint demo: a new trailing action opening a menu with `Edit` / `Danger` sections and a destructive `Delete`

## Testing

Verified on simulators, both paths:

- **iPhone 17 Pro, iOS 26.2** — native `UIMenu` with titled inline sections, SF Symbols, red destructive entry
- **iPhone 16 Pro, iOS 18.5** — action sheet with the titles heading their groups, destructive entry red

`flutter analyze` clean for package and example, iOS build green. I have screenshots of all four cases and can attach them here if useful.

Not run: Android on a device — that path is plain `PopupMenuEntry` composition, but it has not been looked at on a screen.

## Notes

- No formatting-only changes: `dart format` reflows unrelated files in this repo, so I kept the diff to the feature.
- A divider without a title renders as before on iOS 26 and in the action sheet, and an action without `menuItems` keeps firing `onPressed`.
- One deliberate behaviour change, in the Material menu: a divider at index 0 no longer emits a leading `PopupMenuDivider`. That is what lets a title-only divider name the first group without drawing a separator above it. A leading divider drew a line at the very top of the menu before; if you would rather keep that, say so and I will gate it on the title instead.
