### PR TITLE
chore(example): adopt the UIScene lifecycle in the example app

### DIFF
--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -2,12 +2,15 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+
+  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
+    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,29 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneClassName</key>
+					<string>UIWindowScene</string>
+					<key>UISceneConfigurationName</key>
+					<string>flutter</string>
+					<key>UISceneDelegateClassName</key>
+					<string>FlutterSceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,9 +66,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Flutter 3.44 applies this migration to the example project on every build, so anyone building the example finds their working tree modified afterwards. Committing it stops that drift and moves the app onto the scene-based lifecycle iOS expects.

- `Info.plist` declares a `UIApplicationSceneManifest` pointing at `FlutterSceneDelegate` (plus `CADisableMinimumFrameDurationOnPhone`, which the same migration adds)
- `AppDelegate` registers plugins through `FlutterImplicitEngineDelegate.didInitializeImplicitFlutterEngine` instead of doing it in `didFinishLaunchingWithOptions`

## Testing

Built and **run** on an iPhone 17 Pro simulator (iOS 26.2) — the app launches and renders normally. A lifecycle migration can compile fine and still come up to a blank window, so I checked the running app rather than just the build.

## Worth knowing before merging

- Generated with **Flutter 3.44.6 (stable)**. `FlutterSceneDelegate` and `FlutterImplicitEngineDelegate` come from that tooling; on an older Flutter this Info.plist would reference classes the engine does not provide.
- Convenience only — you get the same result by building the example yourself. Close it if you would rather not pin the example to that Flutter version yet.
- Independent of #150 (CocoaPods → SwiftPM) and of #149; the three can land in any order.