### PR TITLE
fix(ios): declare the FlutterFramework dependency in Package.swift

### DIFF
--- a/ios/adaptive_platform_ui/Package.swift
+++ b/ios/adaptive_platform_ui/Package.swift
@@ -11,11 +11,15 @@ let package = Package(
     products: [
         .library(name: "adaptive-platform-ui", targets: ["adaptive_platform_ui"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(name: "FlutterFramework", path: "../FlutterFramework")
+    ],
     targets: [
         .target(
             name: "adaptive_platform_ui",
-            dependencies: []
+            dependencies: [
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ]
         )
     ]
 )


### PR DESCRIPTION
Flutter 3.44 prints this on every build of an app that consumes the plugin as a Swift package:

```
Plugin adaptive_platform_ui has a Package.swift for ios but is missing a dependency on FlutterFramework.
Add the following to your Package.swift dependencies:
    .package(name: "FlutterFramework", path: "../FlutterFramework")
And add FlutterFramework as a target dependency:
    .product(name: "FlutterFramework", package: "FlutterFramework")
```

This applies exactly that. The plugin's Swift sources already `import Flutter`; the manifest just never said so where SwiftPM can see it.

See https://docs.flutter.dev/packages-and-plugins/swift-package-manager/for-plugin-authors

## Testing

Built the example for the simulator afterwards — green, and the notice is gone.

CocoaPods consumers are unaffected: `Package.swift` is only read when SwiftPM is enabled, and the podspec is untouched.