### PR TITLE
feat: borderColor and borderWidth on AdaptiveCard

### DIFF
--- a/example/lib/pages/demos/card_demo_page.dart
+++ b/example/lib/pages/demos/card_demo_page.dart
@@ -67,6 +67,40 @@ class _CardDemoPageState extends State<CardDemoPage> {
         const SizedBox(height: 24),
         _buildSection(
           context,
+          title: 'Custom Border (iOS)',
+          description:
+              'borderColor and borderWidth override the hairline separator',
+          child: Column(
+            children: [
+              AdaptiveCard(
+                margin: const EdgeInsets.only(bottom: 16),
+                padding: const EdgeInsets.all(16),
+                borderColor: PlatformInfo.isIOS
+                    ? CupertinoTheme.of(context).primaryColor
+                    : Colors.blue,
+                child: Text(
+                  'Border in the accent color',
+                  style: _getTextStyle(context),
+                ),
+              ),
+              AdaptiveCard(
+                margin: const EdgeInsets.only(bottom: 16),
+                padding: const EdgeInsets.all(16),
+                borderColor: PlatformInfo.isIOS
+                    ? CupertinoColors.systemRed
+                    : Colors.red,
+                borderWidth: 2,
+                child: Text(
+                  'Two-point red border',
+                  style: _getTextStyle(context),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 24),
+        _buildSection(
+          context,
           title: 'Custom Colors',
           description: 'Cards with custom background colors',
           child: Column(

--- a/lib/src/widgets/adaptive_card.dart
+++ b/lib/src/widgets/adaptive_card.dart
@@ -30,6 +30,8 @@ class AdaptiveCard extends StatelessWidget {
     required this.child,
     this.padding,
     this.borderRadius,
+    this.borderColor,
+    this.borderWidth,
   });
 
   /// The card's background color
@@ -79,6 +81,18 @@ class AdaptiveCard extends StatelessWidget {
   /// On Android: Uses this if shape is not provided
   final BorderRadius? borderRadius;
 
+  /// Colour of the card's border on iOS
+  ///
+  /// Defaults to a hairline separator. Ignored on Android, where the border
+  /// comes from [shape].
+  final Color? borderColor;
+
+  /// Width of the card's border on iOS
+  ///
+  /// Defaults to 0.5 (a hairline), or to 1.0 when [borderColor] is set
+  /// without a width, so a deliberate colour is actually visible.
+  final double? borderWidth;
+
   @override
   Widget build(BuildContext context) {
     final content = padding != null
@@ -93,6 +107,8 @@ class AdaptiveCard extends StatelessWidget {
         clipBehavior: clipBehavior ?? Clip.none,
         semanticContainer: semanticContainer,
         borderRadius: borderRadius,
+        borderColor: borderColor,
+        borderWidth: borderWidth,
         child: content,
       );
     }
@@ -141,6 +157,8 @@ class _IOSCard extends StatelessWidget {
     required this.clipBehavior,
     required this.semanticContainer,
     required this.borderRadius,
+    required this.borderColor,
+    required this.borderWidth,
     required this.child,
   });
 
@@ -149,6 +167,8 @@ class _IOSCard extends StatelessWidget {
   final Clip clipBehavior;
   final bool semanticContainer;
   final BorderRadius? borderRadius;
+  final Color? borderColor;
+  final double? borderWidth;
   final Widget child;
 
   @override
@@ -170,10 +190,12 @@ class _IOSCard extends StatelessWidget {
         color: backgroundColor,
         borderRadius: radius,
         border: Border.all(
-          color: isDark
-              ? CupertinoColors.systemGrey6
-              : CupertinoColors.separator,
-          width: 0.5,
+          color:
+              borderColor ??
+              (isDark
+                  ? CupertinoColors.systemGrey6
+                  : CupertinoColors.separator),
+          width: borderWidth ?? (borderColor != null ? 1.0 : 0.5),
         ),
         boxShadow: isDark
             ? null


### PR DESCRIPTION
The iOS card always draws a hairline separator around itself. An app that wants its cards outlined in the accent colour — a common way to make a card read as tappable or selected — has to wrap the card in another `Container` or fork the widget. We had forked it.

Two optional parameters, both defaulting to today's rendering:

```dart
AdaptiveCard(
  borderColor: CupertinoTheme.of(context).primaryColor,
  child: …,
)

AdaptiveCard(
  borderColor: CupertinoColors.systemRed,
  borderWidth: 2,
  child: …,
)
```

Setting `borderColor` without a width bumps the hairline from 0.5 to 1.0 — at half a point a deliberate colour barely shows, which surprised us when we first tried it. Passing `borderWidth` explicitly always wins.

Android is untouched: there the border comes from `shape`, as before.

## Demo

`card_demo_page` gains a "Custom Border (iOS)" section with both cases, right above the existing "Custom Colors".

## Testing

`flutter analyze` clean for package and example, built and run on an iPhone 17 Pro simulator (iOS 26.2) — screenshot of the new section available if useful.