### PR TITLE
fix: draw the selected radio as a ring with an inner dot

### DIFF
--- a/lib/src/widgets/adaptive_radio.dart
+++ b/lib/src/widgets/adaptive_radio.dart
@@ -149,20 +149,30 @@ class _IOSRadio<T> extends StatelessWidget {
         height: 22,
         decoration: BoxDecoration(
           shape: BoxShape.circle,
-          color: _selected
-              ? activeColor
-              : (isDark
-                    ? CupertinoColors.systemGrey5.darkColor
-                    : CupertinoColors.systemBackground.color),
+          color: isDark
+              ? CupertinoColors.systemGrey5.darkColor
+              : CupertinoColors.systemBackground.color,
           border: Border.all(
             color: _selected
                 ? activeColor
                 : (isDark
                       ? CupertinoColors.systemGrey3.darkColor
                       : CupertinoColors.systemGrey4.color),
-            width: _selected ? 6 : 1.5,
+            width: _selected ? 2 : 1.5,
           ),
         ),
+        child: _selected
+            ? Center(
+                child: Container(
+                  width: 12,
+                  height: 12,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: activeColor,
+                  ),
+                ),
+              )
+            : null,
       ),
     );
   }


### PR DESCRIPTION
The selected state is currently a 6-point border on a 22-point circle. At that ratio the border meets in the middle, so the control renders as a **solid filled disc** — it reads as a bullet or a filled checkbox, not as a radio button.

Both Material and iOS draw a radio the same way: a thin ring, with a separate dot inside it.

This keeps the colours, the size and the unselected state exactly as they are. Only the selected state changes: a 2-point ring in the active colour, with a 12-point dot centred inside.

## Before / after

Same screen (`AdaptiveRadio` demo, iPhone 17 Pro, iOS 26.2), before and after the change. I can attach both images here — GitHub will not let me upload from the CLI.

- **Before:** selected options are solid blue circles
- **After:** selected options are blue rings with a blue dot inside

## Testing

`flutter analyze` clean, example built and run on the simulator, all four radio sections in the demo checked (basic, custom colours, in-card, toggleable).

## Note

This changes the look for every consumer, so it is a judgement call rather than a bug fix — happy to put it behind a flag instead if you would rather keep the current rendering as the default.